### PR TITLE
differentiate between purchase enqueued and status changed to purchased

### DIFF
--- a/InAppPurchase.js
+++ b/InAppPurchase.js
@@ -40,6 +40,7 @@ InAppPurchase.prototype.init = function (options) {
         error:    options.error    || noop,
         ready:    options.ready    || noop,
         purchase: options.purchase || noop,
+        purchaseEnqueued: options.purchaseEnqueued || noop,
         finish:   options.finish   || noop,
         restore:  options.restore  || noop,
         restoreFailed:     options.restoreFailed    || noop,
@@ -89,8 +90,8 @@ InAppPurchase.prototype.purchase = function (productId, quantity) {
     var options = this.options;
     var purchaseOk = function () {
         log('Purchased ' + productId);
-        if (typeof options.purchase === 'function') {
-            protectCall(options.purchase, 'options.purchase', productId, quantity);
+        if (typeof options.purchaseEnqueued === 'function') {
+            protectCall(options.purchaseEnqueued, 'options.purchaseEnqueued', productId, quantity);
         }
     };
     var purchaseFailed = function () {


### PR DESCRIPTION
This fixes a bug due to options.purchase being called with two different method signatures in two different circumstances--after queuing up a new payment, and after the transaction status changing to purchased.
