### PR TITLE
dispose method plopped in the wrong class

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -588,6 +588,16 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void) dispose {
+    self.retainer = nil;
+    self.list = nil;
+    unfinishedTransactions = nil;
+
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+
+    [super dispose];
+}
+
 @end
 
 /**
@@ -646,16 +656,6 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
     CDVPluginResult* pluginResult =
       [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
     [self.plugin.commandDelegate sendPluginResult:pluginResult callbackId:self.command.callbackId];
-}
-
-- (void) dispose {
-    self.retainer = nil;
-    self.list = nil;
-    unfinishedTransactions = nil;
-
-    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
-
-    [super dispose];
 }
 
 #if ARC_DISABLED


### PR DESCRIPTION
It looks to me like you placed the dispose method in BatchProductsRequestDelegate when you intended it to be in InAppPurchase.

I tried out this change in a local phonegap project and get a successful build whereas current master branch causes these errors

```
/Users/aharbick/Sites/boo/platforms/ios/HelloWorld/Plugins/cc.fovea.plugins.inapppurchase/InAppPurchase.m:652:10: error: property 'retainer' not found on object of type
      'BatchProductsRequestDelegate *'
    self.retainer = nil;
         ^
/Users/aharbick/Sites/boo/platforms/ios/HelloWorld/Plugins/cc.fovea.plugins.inapppurchase/InAppPurchase.m:653:10: error: property 'list' not found on object of type
      'BatchProductsRequestDelegate *'
    self.list = nil;
         ^
/Users/aharbick/Sites/boo/platforms/ios/HelloWorld/Plugins/cc.fovea.plugins.inapppurchase/InAppPurchase.m:654:5: error: use of undeclared identifier 'unfinishedTransactions'
    unfinishedTransactions = nil;
    ^
/Users/aharbick/Sites/boo/platforms/ios/HelloWorld/Plugins/cc.fovea.plugins.inapppurchase/InAppPurchase.m:656:62: warning: sending
      'BatchProductsRequestDelegate *const __strong' to parameter of incompatible type 'id<SKPaymentTransactionObserver>'
    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
                                                             ^~~~
In file included from /Users/aharbick/Sites/boo/platforms/ios/HelloWorld/Plugins/cc.fovea.plugins.inapppurchase/InAppPurchase.m:9:
In file included from /Users/aharbick/Sites/boo/platforms/ios/HelloWorld/Plugins/cc.fovea.plugins.inapppurchase/InAppPurchase.h:10:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator7.1.sdk/System/Library/Frameworks/StoreKit.fra
mework/Headers/StoreKit.h:11:
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator7.1.sdk/System/Library/Frameworks/StoreKit.framework/Headers/SKPayme
ntQueue.h:47:70: note: 
      passing argument to parameter 'observer' here
- (void)removeTransactionObserver:(id <SKPaymentTransactionObserver>)observer __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_3_0);
                                                                     ^
/Users/aharbick/Sites/boo/platforms/ios/HelloWorld/Plugins/cc.fovea.plugins.inapppurchase/InAppPurchase.m:658:12: error: no visible @interface for 'NSObject' declares the
      selector 'dispose'
    [super dispose];
     ~~~~~ ^~~~~~~
1 warning and 4 errors generated.
```
