### PR TITLE
Fix an undefined reference error and make log message clearer

### DIFF
--- a/InAppPurchase.js
+++ b/InAppPurchase.js
@@ -101,7 +101,8 @@ InAppPurchase.prototype.purchase = function (productId, quantity) {
     // users to purchase them... leading them to spam us with useless issues and comments.
     // Let's chase them down!
     if ((!InAppPurchase._productIds) || (InAppPurchase._productIds.indexOf(productId) < 0)) {
-        log('purchase error: product needs to be loaded before purchase, call storekit.load(...) first!');
+        var msg = 'Purchasing ' + productId + ' failed.  Ensure the product was loaded first with storekit.load(...)!';
+        log(msg);
         if (typeof options.error === 'function') {
             protectCall(options.error, 'options.error', InAppPurchase.ERR_PURCHASE, msg, productId, quantity);
         }


### PR DESCRIPTION
I'm not picky about the actual message, but I encoutered two problems that lead to this change:
1.  First I was hitting a ReferenceError on msg that was swallowing the message from being returned to user code.
2.  When I fixed that I realized the old log message wouldn't tell you which product was attempting to be purchased.  e.g.

```
   storekit.load(['com.foo.product1'])
   ...
   storekit.purchase('bogus', 1)
```

Should now report an error like "Purchasing bogus failed.  Ensure the product was loaded first with storekit.load(...)!"
