### PR TITLE
fix plugin add --variable BILLING_KEY fail.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -42,7 +42,7 @@
 
     <!-- android -->
     <platform name="android">
-        <!-- preference name="BILLING_KEY" / -->
+        <preference name="BILLING_KEY" />
 
         <js-module src="www/store-android.js" name="InAppBillingPlugin">
             <clobbers target="store" />


### PR DESCRIPTION
https://github.com/j3k0/cordova-plugin-purchase/issues/103
