### PR TITLE
Add triggers for hooking into restore failed or completed

### DIFF
--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -398,6 +398,7 @@ function storekitRestored(originalTransactionId, productId) {
 
 function storekitRestoreCompleted() {
     store.log.info("ios -> restore completed");
+    store.trigger('refresh-completed');
 }
 
 function storekitRestoreFailed(/*errorCode*/) {
@@ -406,6 +407,7 @@ function storekitRestoreFailed(/*errorCode*/) {
         code: store.ERR_REFRESH,
         message: "Failed to restore purchases during refresh"
     });
+    store.trigger('refresh-failed');
 }
 
 store._refreshForValidation = function(callback) {


### PR DESCRIPTION
I recently had an app rejected from the apple store for not having a Restore Previous Purchases button (though this functionality happened automatically on launch).
To get this feature to work properly I implemented these hooks.

The use case is:
If a user launches the app on a new device, but has not signed in with an apple ID yet, calling store.refresh() will prompt the user to login in or create an account. If the user cancels this screen (from failure or whatever reason) or succeeds in logging in I needed some way to display an indication and trigger actions. I couldn't find a pre-existing method to do so without adding these triggers.