### PR TITLE
Updated querySKUDetails to suport more then 20

### DIFF
--- a/src/android/com/smartmobilesoftware/util/IabHelper.java
+++ b/src/android/com/smartmobilesoftware/util/IabHelper.java
@@ -889,14 +889,14 @@ public class IabHelper {
     }
 
     int querySkuDetails(String itemType, Inventory inv, List<String> moreSkus)
-                                throws RemoteException, JSONException {
+            throws RemoteException, JSONException {
         logDebug("Querying SKU details.");
         ArrayList<String> skuList = new ArrayList<String>();
         skuList.addAll(inv.getAllOwnedSkus(itemType));
         if (moreSkus != null) {
-			logDebug("moreSkus: Building SKUs List");
+            logDebug("moreSkus: Building SKUs List");
             for (String sku : moreSkus) {
-				logDebug("moreSkus: "+sku);
+                logDebug("moreSkus: " + sku);
                 if (!skuList.contains(sku)) {
                     skuList.add(sku);
                 }
@@ -908,34 +908,41 @@ public class IabHelper {
             return BILLING_RESPONSE_RESULT_OK;
         }
 
-        Bundle querySkus = new Bundle();
-        querySkus.putStringArrayList(GET_SKU_DETAILS_ITEM_LIST, skuList);
-        Bundle skuDetails = mService.getSkuDetails(3, mContext.getPackageName(),
-                itemType, querySkus);
+        // Split the SKUs into slices of maximum 20 entries before querying them to prevent 
+        // "Input Error: skusBundle array associated with key ITEM_ID_LIST cannot contain more than 20 items."
+        while (skuList.size() > 0) {
+            ArrayList<String> skuSubList = new ArrayList<String>(
+                    skuList.subList(0, Math.min(19, skuList.size())));
+            skuList.removeAll(skuSubList);
 
-        if (!skuDetails.containsKey(RESPONSE_GET_SKU_DETAILS_LIST)) {
-            int response = getResponseCodeFromBundle(skuDetails);
-            if (response != BILLING_RESPONSE_RESULT_OK) {
-                logDebug("getSkuDetails() failed: " + getResponseDesc(response));
-                return response;
+            Bundle querySkus = new Bundle();
+            querySkus.putStringArrayList(GET_SKU_DETAILS_ITEM_LIST, skuSubList);
+            Bundle skuDetails = mService.getSkuDetails(3,
+                    mContext.getPackageName(), itemType, querySkus);
+
+            if (!skuDetails.containsKey(RESPONSE_GET_SKU_DETAILS_LIST)) {
+                int response = getResponseCodeFromBundle(skuDetails);
+                if (response != BILLING_RESPONSE_RESULT_OK) {
+                    logDebug("getSkuDetails() failed: "
+                            + getResponseDesc(response));
+                    return response;
+                } else {
+                    logError("getSkuDetails() returned a bundle with neither an error nor a detail list.");
+                    return ERR_BAD_RESPONSE;
+                }
             }
-            else {
-                logError("getSkuDetails() returned a bundle with neither an error nor a detail list.");
-                return ERR_BAD_RESPONSE;
+
+            ArrayList<String> responseList = skuDetails
+                    .getStringArrayList(RESPONSE_GET_SKU_DETAILS_LIST);
+
+            for (String thisResponse : responseList) {
+                SkuDetails d = new SkuDetails(itemType, thisResponse);
+                logDebug("Got sku details: " + d);
+                inv.addSkuDetails(d);
             }
-        }
-
-        ArrayList<String> responseList = skuDetails.getStringArrayList(
-                RESPONSE_GET_SKU_DETAILS_LIST);
-
-        for (String thisResponse : responseList) {
-            SkuDetails d = new SkuDetails(itemType, thisResponse);
-            logDebug("Got sku details: " + d);
-            inv.addSkuDetails(d);
         }
         return BILLING_RESPONSE_RESULT_OK;
     }
-
 
     void consumeAsyncInternal(final List<Purchase> purchases,
                               final OnConsumeFinishedListener singleListener,

--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -398,6 +398,7 @@ function storekitRestored(originalTransactionId, productId) {
 
 function storekitRestoreCompleted() {
     store.log.info("ios -> restore completed");
+    store.trigger('refresh-completed');
 }
 
 function storekitRestoreFailed(/*errorCode*/) {
@@ -406,6 +407,7 @@ function storekitRestoreFailed(/*errorCode*/) {
         code: store.ERR_REFRESH,
         message: "Failed to restore purchases during refresh"
     });
+    store.trigger('refresh-failed');
 }
 
 store._refreshForValidation = function(callback) {

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1271,6 +1271,7 @@ store.verbosity = 0;
     }
     function storekitRestoreCompleted() {
         store.log.info("ios -> restore completed");
+        store.trigger('refresh-completed');
     }
     function storekitRestoreFailed() {
         store.log.warn("ios -> restore failed");
@@ -1278,6 +1279,7 @@ store.verbosity = 0;
             code: store.ERR_REFRESH,
             message: "Failed to restore purchases during refresh"
         });
+        store.trigger('refresh-failed');
     }
     store._refreshForValidation = function(callback) {
         storekitRefreshReceipts(callback);


### PR DESCRIPTION
The native call to getSkuDetails only supports max 20 entries. 


If you want to query more, you have to slices the SKUs in bundles of queries.