### PR TITLE
add property to hold observer ref, avoid calling multiple times

### DIFF
--- a/src/ios/InAppPurchase.h
+++ b/src/ios/InAppPurchase.h
@@ -21,6 +21,8 @@
 }
 @property (nonatomic,retain) NSMutableDictionary *list;
 @property (nonatomic,retain) NSMutableDictionary *retainer;
+//keep a reference to the transaction observer, to make sure we have only 1 call
+@property (nonatomic,assign) id <SKPaymentTransactionObserver> observer;
 
 - (void) canMakePayments: (CDVInvokedUrlCommand*)command;
 

--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -275,6 +275,7 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
 @implementation InAppPurchase
 @synthesize list;
 @synthesize retainer;
+@synthesize observer;
 
 -(void) debug: (CDVInvokedUrlCommand*)command {
     g_debugEnabled = YES;
@@ -297,7 +298,11 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
     self.list = [[NSMutableDictionary alloc] init];
     self.retainer = [[NSMutableDictionary alloc] init];
     unfinishedTransactions = [[NSMutableDictionary alloc] init];
-    [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
+    //make sure we add only one observer
+    if(observer==nil) {
+        [[SKPaymentQueue defaultQueue]  addTransactionObserver:self];
+        observer = self;
+    }
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"InAppPurchase initialized"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }

--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -645,7 +645,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
     unfinishedTransactions = nil;
 
     [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
-
+    observer = nil;
     [super dispose];
 }
 


### PR DESCRIPTION
in certain occasions calling the addObserver multiple times, can lead to ui prompting user credentials too many times, holding a simple ref we could control this...