### PR TITLE
Set store.plugin so Play Store initializes

### DIFF
--- a/www/store-android.js
+++ b/www/store-android.js
@@ -844,7 +844,7 @@ store.verbosity = 0;
     }
     window.inappbilling = new InAppBilling();
     try {
-        store.inappbilling = window.inappbilling;
+        store.plugin = window.inappbilling;
     } catch (e) {}
 })();
 


### PR DESCRIPTION
Getting this error on Android:

```
 [INFO:CONSOLE(460)] "[store.js] WARNING:            TypeError: Cannot read property 'init' of undefined
     at init (file:///android_asset/www/plugins/cc.fovea.cordova.purchase/www/store-android.js:876:21)
     at Object.<anonymous> (file:///android_asset/www/plugins/cc.fovea.cordova.purchase/www/store-android.js:856:27)
     at Object.store._queries.triggerAction (file:///android_asset/www/plugins/cc.fovea.cordova.purchase/www/store-android.js:575:35)
     at Object.store.trigger (file:///android_asset/www/plugins/cc.fovea.cordova.purchase/www/store-android.js:627:28)
     at Object.store.refresh (file:///android_asset/www/plugins/cc.fovea.cordova.purchase/www/store-android.js:433:15)
     at registerProducts (file:///android_asset/www/js/base-app.js:2290:20)
```

This line change should fix it.