### PR TITLE
fix retrying store#refresh() error.

### DIFF
--- a/www/store-android.js
+++ b/www/store-android.js
@@ -428,11 +428,9 @@ store.verbosity = 0;
 
 (function() {
     "use strict";
-    var initialRefresh = true;
     store.refresh = function() {
         store.trigger("refreshed");
-        if (initialRefresh) {
-            initialRefresh = false;
+        if (!store.ready()) {
             return;
         }
         store.log.debug("refresh -> checking products state (" + store.products.length + " products)");


### PR DESCRIPTION
fix retrying store#refresh() error.

1. Turn off my WiFi connection.
2. Execute store#refresh(), then request failed on error. 
3. Turn on my WiFi connection.
4. Execute store#refresh() again. Though the connection valid, but request is failed with next error.

`{code: 6777019, message: "refresh failed - Billing plugin was not initialized"}`


I think that it should be suppressed to trigger the "re-refreshed" event on secondary store#refresh() while initialization is not complete. 