### PR TITLE
Remove duplicate calls to downloading() promise

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -13,7 +13,7 @@
 // Help create NSNull objects for nil items (since neither NSArray nor NSDictionary can store nil values).
 #define NILABLE(obj) ((obj) != nil ? (NSObject *)(obj) : (NSObject *)[NSNull null])
 
-static BOOL g_debugEnabled = YES;
+static BOOL g_debugEnabled = NO;
 static BOOL g_autoFinishEnabled = YES;
 
 #define DLog(fmt, ...) { \

--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -439,7 +439,6 @@ function storekitDownloadActive(transactionIdentifier, productId, progress, time
         timeRemaining: timeRemaining,
         state: store.DOWNLOADING
     });
-    p.stateChanged();
 }
 function storekitDownloadFailed(transactionIdentifier, productId, errorCode, errorText) {
     store.log.error("ios -> download failed: " + productId + "; errorCode=" + errorCode + "; errorText=" + errorText);

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1400,7 +1400,6 @@ store.verbosity = 0;
             timeRemaining: timeRemaining,
             state: store.DOWNLOADING
         });
-        p.stateChanged();
     }
     function storekitDownloadFailed(transactionIdentifier, productId, errorCode, errorText) {
         store.log.error("ios -> download failed: " + productId + "; errorCode=" + errorCode + "; errorText=" + errorText);


### PR DESCRIPTION
These commits fix #292 
Also set `static BOOL g_debugEnabled = NO;` by default, since setting `store.verbosity = store.DEBUG;` sets it to `YES`