### PR TITLE
Fix testmode for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You're all good? Time to read some more documentation. Hooray!
  - [API Documentation](doc/api.md)
  - [Documentation for iOS](doc/ios.md)
  - [Documentation for Android](doc/android.md)
- - [Documentation for Windows](doc/android.md)
+ - [Documentation for Windows](doc/windows.md)
 
 ## Resources
 

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -5,10 +5,11 @@ To enable the IAP similator you will need to call the testmode function on the p
 Doing this will route purchases through the simulator which will allow the user to select the outcome of the purchase (selecting success or failure types).
 
 ```
-store.inappbilling.setTestMode(true); //Don't call this in production
+store.inappbilling.setTestMode(); //Don't call this in production
 ```
 
-Sample simmilator xml file (put this inside the `www` folder in your cordova app)
+####Sample simmilator xml file.
+Put this inside the `www` folder in your cordova app or in `merges\windows` for only windows platform.
 ```
 <?xml version="1.0" encoding="utf-16" ?>
 <CurrentApp>

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -6,6 +6,14 @@ Doing this will route purchases through the simulator which will allow the user 
 
 ```
 store.inappbilling.setTestMode(); //Don't call this in production
+
+//Optionally add callbacks
+store.inappbilling.setTestMode(function() {
+    //successfully loaded test data
+  },
+  function() {
+    //failed to load test data
+  });
 ```
 
 ####Sample simmilator xml file.
@@ -51,5 +59,8 @@ I could not get the `make build` script working on windows but to build the `sto
 ```
 npm install
 node_modules\.bin\preprocess src\js\store-windows.js src\js > www\store-windows.js
+node_modules\.bin\uglifyjs www\store-windows.js -b -o www\store-windows.js
+
 node_modules\.bin\preprocess src\js\store-android.js src\js > www\store-android.js
+node_modules\.bin\uglifyjs www\store-android.js -b -o www\store-android.js
 ```

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -1,7 +1,7 @@
 # Windows (Store/Phone 8.1) Configuration
 
 ## Test setup
-To enable the IAP similator you will need to call the testmode function on the plugin and add the store simulator xml file with your items.
+To enable the IAP simulator you will need to call the testmode function on the plugin and add the store simulator xml file with your items.
 Doing this will route purchases through the simulator which will allow the user to select the outcome of the purchase (selecting success or failure types).
 
 ```
@@ -16,7 +16,7 @@ store.inappbilling.setTestMode(function() {
   });
 ```
 
-####Sample simmilator xml file.
+####Sample simulator xml file.
 Put this inside the `www` folder in your cordova app or in `merges\windows` for only windows platform.
 ```
 <?xml version="1.0" encoding="utf-16" ?>

--- a/src/js/platforms/plugin-bridge.js
+++ b/src/js/platforms/plugin-bridge.js
@@ -111,11 +111,11 @@ InAppBilling.prototype.getProductDetails = function (success, fail, skus) {
 		cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "getProductDetails", [skus]);
     }
 };
-InAppBilling.prototype.setTestMode = function (testMode) {
+InAppBilling.prototype.setTestMode = function (success, fail) {
 	if (this.options.showLog) {
 		log('setTestMode called!');
 	}
-	return cordova.exec(null, null, "InAppBillingPlugin", "setTestMode", [testMode]);
+	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "setTestMode", [""]);
 };
 
 // Generates a `fail` function that accepts an optional error code

--- a/src/windows/InAppPurchaseProxy.js
+++ b/src/windows/InAppPurchaseProxy.js
@@ -1,40 +1,34 @@
 ﻿var cordova = require('cordova');
 
 module.exports = {
-    setTestMode: function(args){
+    setTestMode: function(win, fail, args){
         //switch between live and similator mode for IAP testing
-        var testMode = args[0];
-        if (testMode){
-            this.currentApp = Windows.ApplicationModel.Store.CurrentAppSimulator;
-            
-            Windows.ApplicationModel.Package.current.installedLocation.getFolderAsync("www").done(
-                function (folder) {
-                    folder.getFileAsync("in-app-purchase.xml").done(
-                        function (file) {
-                            console.log("got the xml file for currentAppSimulator", file);
-                            this.currentApp.reloadSimulatorAsync(file).done(
-                                function () {
-                                    // Get the license info
-                                    this.productLicenses = this.currentApp.licenseInformation.productLicenses;
-                                    if (this.currentApp && this.productLicenses) {
-                                        console.log("loaded xml file");
-                                    } else {
-                                        console.log("failed xml file");
-                                    }
-                                }.bind(this),
-                                function (err) {
-                                    console.log("This is still not working!!");
-                                    console.log(err);
-    
+        this.currentApp = Windows.ApplicationModel.Store.CurrentAppSimulator;
+        
+        Windows.ApplicationModel.Package.current.installedLocation.getFolderAsync("www").done(
+            function (folder) {
+                folder.getFileAsync("in-app-purchase.xml").done(
+                    function (file) {
+                        console.log("got the xml file for currentAppSimulator", file);
+                        this.currentApp.reloadSimulatorAsync(file).done(
+                            function () {
+                                // Get the license info
+                                this.productLicenses = this.currentApp.licenseInformation.productLicenses;
+                                if (this.currentApp && this.productLicenses) {
+                                    console.log("loaded xml file");
+                                } else {
+                                    console.log("failed xml file");
                                 }
-                            );
-                        }.bind(this));
-                }.bind(this)
-            );
-        }
-        else {
-            this.currentApp = Windows.ApplicationModel.Store.CurrentApp;
-        }
+                            }.bind(this),
+                            function (err) {
+                                console.log("This is still not working!!");
+                                console.log(err);
+
+                            }
+                        );
+                    }.bind(this));
+            }.bind(this)
+        );
     },    
     init: function (win, fail, args) {
         if (!this.currentApp){

--- a/src/windows/InAppPurchaseProxy.js
+++ b/src/windows/InAppPurchaseProxy.js
@@ -16,14 +16,16 @@ module.exports = {
                                 this.productLicenses = this.currentApp.licenseInformation.productLicenses;
                                 if (this.currentApp && this.productLicenses) {
                                     console.log("loaded xml file");
+                                    win();
                                 } else {
                                     console.log("failed xml file");
+                                    fail();
                                 }
                             }.bind(this),
                             function (err) {
                                 console.log("This is still not working!!");
                                 console.log(err);
-
+                                fail();
                             }
                         );
                     }.bind(this));

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -823,11 +823,11 @@ store.verbosity = 0;
             cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "getProductDetails", [ skus ]);
         }
     };
-    InAppBilling.prototype.setTestMode = function(testMode) {
+    InAppBilling.prototype.setTestMode = function(success, fail) {
         if (this.options.showLog) {
             log("setTestMode called!");
         }
-        return cordova.exec(null, null, "InAppBillingPlugin", "setTestMode", [ testMode ]);
+        return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "setTestMode", [ "" ]);
     };
     function errorCb(fail) {
         return function(error) {


### PR DESCRIPTION
setTestMode on windows now takes callback args instead of a bool.

This fixes it loading the simulator xml file and adds the ability to handle when it's done loading the file contents.

Should fix #294 