### PR TITLE
Fix for prompt appearing on app start

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -108,13 +108,13 @@ char* base64(const void* binaryData, int len, int *flen)
 {
   const unsigned char* bin = (const unsigned char*) binaryData ;
   char* res ;
-  
+
   int rc = 0 ; // result counter
   int byteNo ; // I need this after the loop
-  
+
   int modulusLen = len % 3 ;
   int pad = ((modulusLen&1)<<1) + ((modulusLen&2)>>1) ; // 2 gives 1 and 1 gives 2, but 0 gives 0.
-  
+
   *flen = 4*(len + pad)/3 ;
   res = (char*) malloc( *flen + 1 ) ; // and one for the null
   if( !res )
@@ -123,7 +123,7 @@ char* base64(const void* binaryData, int len, int *flen)
     puts( "I must stop because I could not get enough" ) ;
     return 0;
   }
-  
+
   for( byteNo = 0 ; byteNo <= len-3 ; byteNo+=3 )
   {
     unsigned char BYTE0=bin[byteNo];
@@ -134,7 +134,7 @@ char* base64(const void* binaryData, int len, int *flen)
     res[rc++]  = b64[ ((0x0f&BYTE1)<<2) + (BYTE2>>6) ] ;
     res[rc++]  = b64[ 0x3f&BYTE2 ] ;
   }
-  
+
   if( pad==2 )
   {
     res[rc++] = b64[ bin[byteNo] >> 2 ] ;
@@ -149,7 +149,7 @@ char* base64(const void* binaryData, int len, int *flen)
     res[rc++]  = b64[ (0x0f&bin[byteNo+1])<<2 ] ;
     res[rc++] = '=';
   }
-  
+
   res[rc] = 0; // NULL TERMINATOR! ;)
   return res ;
 }
@@ -170,7 +170,7 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
   }
   if( safeAsciiPtr[ len-1 ]=='=' )  ++pad ;
   if( safeAsciiPtr[ len-2 ]=='=' )  ++pad ;
-  
+
   *flen = 3*len/4 - pad ;
   bin = (unsigned char*)malloc( *flen ) ;
   if( !bin )
@@ -179,25 +179,25 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
     puts( "I must stop because I could not get enough" ) ;
     return 0;
   }
-  
+
   for( charNo=0; charNo <= len - 4 - pad ; charNo+=4 )
   {
     int A=unb64[safeAsciiPtr[charNo]];
     int B=unb64[safeAsciiPtr[charNo+1]];
     int C=unb64[safeAsciiPtr[charNo+2]];
     int D=unb64[safeAsciiPtr[charNo+3]];
-    
+
     bin[cb++] = (A<<2) | (B>>4) ;
     bin[cb++] = (B<<4) | (C>>2) ;
     bin[cb++] = (C<<6) | (D) ;
   }
-  
+
   if( pad==1 )
   {
     int A=unb64[safeAsciiPtr[charNo]];
     int B=unb64[safeAsciiPtr[charNo+1]];
     int C=unb64[safeAsciiPtr[charNo+2]];
-    
+
     bin[cb++] = (A<<2) | (B>>4) ;
     bin[cb++] = (B<<4) | (C>>2) ;
   }
@@ -205,10 +205,10 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
   {
     int A=unb64[safeAsciiPtr[charNo]];
     int B=unb64[safeAsciiPtr[charNo+1]];
-    
+
     bin[cb++] = (A<<2) | (B>>4) ;
   }
-  
+
   return bin;
 }
 */
@@ -333,7 +333,7 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }
-    
+
     NSSet *productIdentifiers = [NSSet setWithArray:inArray];
     DLog(@"Set has %li elements", (unsigned long)[productIdentifiers count]);
     for (NSString *item in productIdentifiers) {
@@ -375,7 +375,7 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
 - (void) canMakePayments: (CDVInvokedUrlCommand*)command
 {
   CDVPluginResult* pluginResult = nil;
-  
+
   if (![SKPaymentQueue canMakePayments]) {
         DLog(@"Device can't make payments.");
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Can't make payments"];
@@ -384,7 +384,7 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
     DLog(@"Device can make payments.");
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Can make payments"];
   }
-  
+
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
@@ -397,7 +397,7 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
 {
     NSArray *dls = [self.currentDownloads allValues];
     DLog(@"Pausing %d active downloads...",[dls count]);
-    
+
     [[SKPaymentQueue defaultQueue] pauseDownloads:dls];
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -499,6 +499,10 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
         // DLog(@"js: %@", js);
         [self.commandDelegate evalJs:js];
 
+        if (canFinish){
+          [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+        }
+
         if (downloads && [downloads count] > 0) {
             [[SKPaymentQueue defaultQueue] startDownloads:downloads];
         }
@@ -591,7 +595,7 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
 }
 /*
 I started to implement client side receipt validation. However, this requires the inclusion of OpenSSL into the source, which is probably behong what storekit plugin should do. So I choose only to provide base64 encoded receipts to the user, then he can deal with them the way he wants...
- 
+
 The code bellow may eventually work... it is untested
 
 static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQswCQYDVQQGEwJVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwHhcNMDYwNDI1MjE0MDM2WhcNMzUwMjA5MjE0MDM2WjBiMQswCQYDVQQGEwJVUzETMBEGA1UEChMKQXBwbGUgSW5jLjEmMCQGA1UECxMdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxFjAUBgNVBAMTDUFwcGxlIFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDkkakJH5HbHkdQ6wXtXnmELes2oldMVeyLGYne+Uts9QerIjAC6Bg++FAJ039BqJj50cpmnCRrEdCju+QbKsMflZ56DKRHi1vUFjczy8QPTc4UadHJGXL1XQ7Vf1+b8iUDulWPTV0N8WQ1IxVLFVkds5T39pyez1C6wVhQZ48ItCD3y6wsIG9wtj8BMIy3Q88PnT3zK0koGsj+zrW5DtleHNbLPbU6rfQPDgCSC7EhFi501TwN22IWq6NxkkdTVcGvL0Gz+PvjcM3mo0xFfh9Ma1CWQYnEdGILEINBhzOKgbEwWOxaBDKMaLOPHd5lc/9nXmW8Sdh2nzMUZaF3lMktAgMBAAGjggF6MIIBdjAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUK9BpR5R2Cf70a40uQKb3R01/CF4wHwYDVR0jBBgwFoAUK9BpR5R2Cf70a40uQKb3R01/CF4wggERBgNVHSAEggEIMIIBBDCCAQAGCSqGSIb3Y2QFATCB8jAqBggrBgEFBQcCARYeaHR0cHM6Ly93d3cuYXBwbGUuY29tL2FwcGxlY2EvMIHDBggrBgEFBQcCAjCBthqBs1JlbGlhbmNlIG9uIHRoaXMgY2VydGlmaWNhdGUgYnkgYW55IHBhcnR5IGFzc3VtZXMgYWNjZXB0YW5jZSBvZiB0aGUgdGhlbiBhcHBsaWNhYmxlIHN0YW5kYXJkIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mIHVzZSwgY2VydGlmaWNhdGUgcG9saWN5IGFuZCBjZXJ0aWZpY2F0aW9uIHByYWN0aWNlIHN0YXRlbWVudHMuMA0GCSqGSIb3DQEBBQUAA4IBAQBcNplMLXi37Yyb3PN3m/J20ncwT8EfhYOFG5k9RzfyqZtAjizUsZAS2L70c5vu0mQPy3lPNNiiPvl4/2vIB+x9OYOLUyDTOMSxv5pPCmv/K/xZpwUJfBdAVhEedNO3iyM7R6PVbyTi69G3cN8PReEnyvFteO3ntRcXqNx+IjXKJdXZD9Zr1KIkIxH3oayPc4FgxhtbCS+SsvhESPBgOJ4V9T0mZyCKM2r3DYLP3uujL/lTaltkwGMzd/c6ByxW69oPIQ7aunMZT7XZNn/Bh1XZp5m5MkL72NVxnn6hUrcbvZNCJBIqxw8dtk2cXmPIS4AXUKqK1drk/NAJBzewdXUh";
@@ -622,7 +626,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
         // Verify the signature
         BIO *b_receiptPayload;
         int result = PKCS7_verify(p7, NULL, store, b_receiptPayload, 0);
- 
+
         free(receiptBytes);
         free(appleBytes);
 
@@ -663,7 +667,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
     recreq.delegate = delegate;
     delegate.plugin  = self;
     delegate.command = command;
-    
+
 #if ARC_ENABLED
     self.retainer[@"receiptRefreshRequest"] = recreq;
     self.retainer[@"receiptRefreshRequestDelegate"] = delegate;
@@ -692,7 +696,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
 // Download Queue
 - (void) paymentQueue:(SKPaymentQueue *)queue updatedDownloads:(NSArray *)downloads
 {
-    
+
     for (SKDownload *download in downloads)
     {
         NSString *state = @"";
@@ -700,103 +704,103 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
         NSInteger errorCode = 0;
         NSString *progress_s = 0;
         NSString *timeRemaining_s = 0;
-        
+
         SKPaymentTransaction *transaction = download.transaction;
         NSString *transactionId = transaction.transactionIdentifier;
         NSString *transactionReceipt = [[transaction transactionReceipt] cdv_base64EncodedString];
         SKPayment *payment = transaction.payment;
         NSString *productId = payment.productIdentifier;
-        
+
         NSArray *callbackArgs;
         NSString *js;
-        
+
         switch (download.downloadState)
         {
             case SKDownloadStateActive:
             {
                 // Add to current downloads
                 [self.currentDownloads setObject:download forKey:productId];
-                
+
                 state = @"DownloadStateActive";
-                
+
                 DLog(@"Progress: %f", download.progress);
                 DLog(@"Time remaining: %f", download.timeRemaining);
-                
+
                 progress_s = [NSString stringWithFormat:@"%d", (int) (download.progress*100)];
                 timeRemaining_s = [NSString stringWithFormat:@"%d", (int) download.timeRemaining];
-                
+
                 break;
             }
-                
+
             case SKDownloadStateCancelled: {
                 // Remove from current downloads
                 [self.currentDownloads removeObjectForKey:productId];
-                
+
                 state = @"DownloadStateCancelled";
                 [[SKPaymentQueue defaultQueue] finishTransaction:download.transaction];
                 [self transactionFinished:download.transaction];
-                
+
                 break;
             }
             case SKDownloadStateFailed:
             {
                 // Remove from current downloads
                 [self.currentDownloads removeObjectForKey:productId];
-                
+
                 state = @"DownloadStateFailed";
                 error = transaction.error.localizedDescription;
                 errorCode = transaction.error.code;
                 DLog(@"Download error %d %@", errorCode, error);
                 [[SKPaymentQueue defaultQueue] finishTransaction:download.transaction];
                 [self transactionFinished:download.transaction];
-                
+
                 break;
             }
-                
+
             case SKDownloadStateFinished:
             {
                 // Remove from current downloads
                 [self.currentDownloads removeObjectForKey:productId];
-                
+
                 state = @"DownloadStateFinished";
                 [[SKPaymentQueue defaultQueue] finishTransaction:download.transaction];
                 [self transactionFinished:download.transaction];
-                
+
                 [self copyDownloadToDocuments:download]; // Copy download content to Documnents folder
-                
+
                 break;
             }
-                
+
             case SKDownloadStatePaused:
             {
                 // Add to current downloads
                 [self.currentDownloads setObject:download forKey:productId];
-                
+
                 state = @"DownloadStatePaused";
-                
+
                 break;
             }
-                
+
             case SKDownloadStateWaiting:
             {
                 // Add to current downloads
                 [self.currentDownloads setObject:download forKey:productId];
                 state = @"DownloadStateWaiting";
-                
+
                 break;
             }
-                
+
             default:
             {
                 DLog(@"Invalid Download State");
                 return;
             }
         }
-        
+
         DLog(@"Number of currentDownloads: %d",[self.currentDownloads count]);
         DLog(@"Product %@ in download state: %@", productId, state);
-        
-        
+
+
         callbackArgs = [NSArray arrayWithObjects:
                                  NILABLE(state),
                                  [NSNumber numberWithInt:errorCode],
@@ -811,7 +815,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
                         stringWithFormat:@"window.storekit.updatedDownloadCallback.apply(window.storekit, %@)",
                         [callbackArgs JSONSerialize]];
         [self.commandDelegate evalJs:js];
-        
+
     }
 }
 
@@ -822,13 +826,13 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
 
 - (void)copyDownloadToDocuments:(SKDownload *)download {
     DLog(@"Copying downloaded content to Documents...");
-    
+
     NSString *source = [download.contentURL relativePath];
     NSDictionary *dict = [[NSMutableDictionary alloc] initWithContentsOfFile:[source stringByAppendingPathComponent:@"ContentInfo.plist"]];
     NSString *targetFolder = [FileUtility getDocumentPath];
     NSString *content = [source stringByAppendingPathComponent:@"Contents"];
     NSArray *files;
-    
+
     // Use folder if specified in .plist
     if([dict objectForKey:@"Folder"]){
         targetFolder = [targetFolder stringByAppendingPathComponent:[dict objectForKey:@"Folder"]];
@@ -837,7 +841,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
             NSAssert([FileUtility createFolder:targetFolder], @"Failed to create Documents subfolder: %@", targetFolder);
         }
     }
-    
+
     if ([dict objectForKey:@"Files"]){
         DLog(@"Found Files key in .plist");
         files =  [dict objectForKey:@"Files"];
@@ -845,25 +849,25 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
         DLog(@"No Files key found in .plist - copy all files in Content folder");
         files = [FileUtility listFiles:content extension:nil];
     }
-    
+
     for (NSString *file in files)
     {
         NSString *fcontent = [content stringByAppendingPathComponent:file];
         NSString *targetFile = [targetFolder stringByAppendingPathComponent:[file lastPathComponent]];
-        
+
         DLog(@"Content path: %@", fcontent);
-        
+
         NSAssert([FileUtility isFileExist:fcontent], @"Content path MUST be valid");
-        
+
         // Copy the content to the documents folder
         NSAssert([FileUtility copyFile:fcontent dst:targetFile], @"Failed to copy the content");
         DLog(@"Copied %@ to %@", fcontent, targetFile);
-        
+
         // Set flag so we don't backup on iCloud
         NSURL* url = [NSURL fileURLWithPath:targetFile];
         [url setResourceValue: [NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: Nil];
     }
-    
+
 }
 
 @end
@@ -915,7 +919,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
 
 #if ARC_DISABLED
 - (void) dealloc {
-    [plugin  release];   
+    [plugin  release];
     [command release];
     [super   dealloc];
 }


### PR DESCRIPTION
This fix solves the problem of the reappearing sign in prompt on app start which was cause by transactions being stuck in a unfinished state and therefore the observer always tried to finish does transactions.
This is probably not the nicest fix but it works and has been tested with 3 different apps. 
If you have a better way of fixing this go ahead but at least with this pull request the plugin can be used without the annoying prompts
