### PR TITLE
Add currencyCode to product details for iOS

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -937,6 +937,13 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
     NSMutableArray *validProducts = [NSMutableArray array];
     DLog(@"Has %li validProducts", (unsigned long)[response.products count]);
     for (SKProduct *product in response.products) {
+        // Get the currency code from the NSLocale object
+        NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+        [numberFormatter setFormatterBehavior:NSNumberFormatterBehavior10_4];
+        [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
+        [numberFormatter setLocale:product.priceLocale];
+        NSString *currencyCode = [numberFormatter currencyCode];
+        
         DLog(@" - %@: %@", product.productIdentifier, product.localizedTitle);
         [validProducts addObject:
          [NSDictionary dictionaryWithObjectsAndKeys:
@@ -944,6 +951,7 @@ static NSString *rootAppleCA = @"MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQs
           NILABLE(product.localizedTitle),       @"title",
           NILABLE(product.localizedDescription), @"description",
           NILABLE(product.localizedPrice),       @"price",
+          NILABLE(currencyCode),                 @"currency",
           nil]];
         [self.plugin.list setObject:product forKey:[NSString stringWithFormat:@"%@", product.productIdentifier]];
     }

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1241,6 +1241,7 @@ store.verbosity = 0;
                 title: validProducts[i].title,
                 price: validProducts[i].price,
                 description: validProducts[i].description,
+                currency: validProducts[i].currency,
                 state: store.VALID
             });
             p.trigger("loaded");


### PR DESCRIPTION
As the currencyCode returns null for iOS, I have extended the code to return this, as we need it for our current project for transaction capturing on our server. Kindly request to review and merge this with the master branch.