### PR TITLE
Fixed the case that product.transaction is null in storekitFinish

### DIFF
--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -57,7 +57,7 @@ store.when("finished", function(product) {
 
 function storekitFinish(product) {
     if (product.type === store.CONSUMABLE) {
-        if (product.transaction.id)
+        if (product.transaction && product.transaction.id)
             storekit.finish(product.transaction.id);
     }
     else if (product.transactions) {


### PR DESCRIPTION
If user push cancel to signin iTunes Store, we get this WARNING.
```
WARNING:            storekitFinish@file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:1162:36
file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:1155:23
triggerWhenProduct@file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:600:44
trigger@file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:640:42
trigger@file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:529:22
stateChanged@file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:517:37
set@file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:500:51
file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:85:25
file:///.../PurchaseDemo.app/www/plugins/cc.fovea.cordova.purchase/www/store-ios.js:56:20
```

product.transaction is null, but your code try to evaluate product.transaction.id, and then, WARNING occurred.

This pull request is a simple way to resolve above error.
Please check and fix this error.

Thank you for checking and reading my first pull request in my life. 
