### PR TITLE
fix to handle error message is nil

### DIFF
--- a/src/js/error.js
+++ b/src/js/error.js
@@ -39,14 +39,12 @@ store.error = function(cb, altCb) {
 
     var ret = cb;
 
-    if (cb instanceof store.Error)
+    if (cb instanceof store.Error) {
         store.error.callbacks.trigger(cb);
-
-    else if (cb.code && cb.message)
-        store.error.callbacks.trigger(new store.Error(cb));
-
-    else if (typeof cb === "function")
+    }
+    else if (typeof cb === "function") {
         store.error.callbacks.push(cb);
+    }
 
     /// ### alternative usage
     ///
@@ -59,6 +57,13 @@ store.error = function(cb, altCb) {
                 altCb();
         };
         store.error(ret);
+    }
+    else if (cb.code && cb.message) {
+        store.error.callbacks.trigger(new store.Error(cb));
+    }
+    else if (cb.code) {
+        // error message is null(unknown error)
+        store.error.callbacks.trigger(new store.Error(cb));
     }
     ///
 


### PR DESCRIPTION
About iOS 8.

If store.order is called when the device is offline, SKPaymentTransactionStateFailed is occurred.
Then, if the device is iOS8.*, transaction.error is nil, errorText is undefined(cb.message is undefined) and we cannot catch this error through store.error callback.

I think we should catch above error through store.error callback with error message is "unknown error".
This pull request adds the case cb.code !== undefined and cb.message === undefined to call store.error callback.

Thanks.