### PR TITLE
Update store-ios.js

### DIFF
--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1038,7 +1038,7 @@ store.verbosity = 0;
                 bundleNumericVersion: bundleNumericVersion,
                 bundleSignature: bundleSignature
             });
-            protectCall(successCb, "refreshReceipts.success", base64);
+            protectCall(successCb, "refreshReceipts.success", args);
         };
         var error = function(errMessage) {
             log("refresh receipt failed: " + errMessage);


### PR DESCRIPTION
In ios-adapter.js on the store.when("re-refreshed") event refreshReceipts is called with a callback function that takes one argument. This argument is considered to have an attribute of bundleIdentifier. However it is impossible for this argument to have a bundleIdentifier attribute, since at can only be the base64 variable (raw data string). So there must be a bug either in store-ios.js or in ios-adapter.js.