### PR TITLE
Fix to allow non-renewable subscription purchases for iOS

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -8,10 +8,11 @@
 ///
 /// ### product types
 ///
-/*///*/     store.FREE_SUBSCRIPTION = "free subscription";
-/*///*/     store.PAID_SUBSCRIPTION = "paid subscription";
-/*///*/     store.CONSUMABLE        = "consumable";
-/*///*/     store.NON_CONSUMABLE    = "non consumable";
+/*///*/     store.FREE_SUBSCRIPTION         = "free subscription";
+/*///*/     store.PAID_SUBSCRIPTION         = "paid subscription";
+/*///*/     store.NON_RENEWING_SUBSCRIPTION = "non renewing subscription";
+/*///*/     store.CONSUMABLE                = "consumable";
+/*///*/     store.NON_CONSUMABLE            = "non consumable";
 
 ///
 /// ### error codes

--- a/src/js/product.js
+++ b/src/js/product.js
@@ -31,7 +31,7 @@ store.Product = function(options) {
 
     ///  - `product.type` - Family of product, should be one of the defined [product types](#product-types).
     var type = this.type = options.type || null;
-    if (type !== store.CONSUMABLE && type !== store.NON_CONSUMABLE && type !== store.PAID_SUBSCRIPTION && type !== store.FREE_SUBSCRIPTION)
+    if (type !== store.CONSUMABLE && type !== store.NON_CONSUMABLE && type !== store.PAID_SUBSCRIPTION && type !== store.FREE_SUBSCRIPTION && type !== store.NON_RENEWING_SUBSCRIPTION)
         throw new TypeError("Invalid product type");
 
     ///  - `product.state` - Current state the product is in (see [life-cycle](#life-cycle) below). Should be one of the defined [product states](#product-states)

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -8,6 +8,7 @@ store.sandbox = false;
     "use strict";
     store.FREE_SUBSCRIPTION = "free subscription";
     store.PAID_SUBSCRIPTION = "paid subscription";
+    store.NON_RENEWING_SUBSCRIPTION = "non renewing subscription";
     store.CONSUMABLE = "consumable";
     store.NON_CONSUMABLE = "non consumable";
     var ERROR_CODES_BASE = 6777e3;
@@ -64,7 +65,7 @@ store.sandbox = false;
         this.id = options.id || null;
         this.alias = options.alias || options.id || null;
         var type = this.type = options.type || null;
-        if (type !== store.CONSUMABLE && type !== store.NON_CONSUMABLE && type !== store.PAID_SUBSCRIPTION && type !== store.FREE_SUBSCRIPTION) throw new TypeError("Invalid product type");
+        if (type !== store.CONSUMABLE && type !== store.NON_CONSUMABLE && type !== store.PAID_SUBSCRIPTION && type !== store.FREE_SUBSCRIPTION && type !== store.NON_RENEWING_SUBSCRIPTION) throw new TypeError("Invalid product type");
         this.state = options.state || "";
         this.title = options.title || options.localizedTitle || null;
         this.description = options.description || options.localizedDescription || null;
@@ -189,11 +190,19 @@ store.sandbox = false;
     };
     store.error = function(cb, altCb) {
         var ret = cb;
-        if (cb instanceof store.Error) store.error.callbacks.trigger(cb); else if (cb.code && cb.message) store.error.callbacks.trigger(new store.Error(cb)); else if (typeof cb === "function") store.error.callbacks.push(cb); else if (typeof altCb === "function") {
+        if (cb instanceof store.Error) {
+            store.error.callbacks.trigger(cb);
+        } else if (typeof cb === "function") {
+            store.error.callbacks.push(cb);
+        } else if (typeof altCb === "function") {
             ret = function(err) {
                 if (err.code === cb) altCb();
             };
             store.error(ret);
+        } else if (cb.code && cb.message) {
+            store.error.callbacks.trigger(new store.Error(cb));
+        } else if (cb.code) {
+            store.error.callbacks.trigger(new store.Error(cb));
         }
         return ret;
     };

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -8,6 +8,7 @@ store.sandbox = false;
     "use strict";
     store.FREE_SUBSCRIPTION = "free subscription";
     store.PAID_SUBSCRIPTION = "paid subscription";
+    store.NON_RENEWING_SUBSCRIPTION = "non renewing subscription";
     store.CONSUMABLE = "consumable";
     store.NON_CONSUMABLE = "non consumable";
     var ERROR_CODES_BASE = 6777e3;
@@ -64,7 +65,7 @@ store.sandbox = false;
         this.id = options.id || null;
         this.alias = options.alias || options.id || null;
         var type = this.type = options.type || null;
-        if (type !== store.CONSUMABLE && type !== store.NON_CONSUMABLE && type !== store.PAID_SUBSCRIPTION && type !== store.FREE_SUBSCRIPTION) throw new TypeError("Invalid product type");
+        if (type !== store.CONSUMABLE && type !== store.NON_CONSUMABLE && type !== store.PAID_SUBSCRIPTION && type !== store.FREE_SUBSCRIPTION && type !== store.NON_RENEWING_SUBSCRIPTION) throw new TypeError("Invalid product type");
         this.state = options.state || "";
         this.title = options.title || options.localizedTitle || null;
         this.description = options.description || options.localizedDescription || null;
@@ -189,11 +190,19 @@ store.sandbox = false;
     };
     store.error = function(cb, altCb) {
         var ret = cb;
-        if (cb instanceof store.Error) store.error.callbacks.trigger(cb); else if (cb.code && cb.message) store.error.callbacks.trigger(new store.Error(cb)); else if (typeof cb === "function") store.error.callbacks.push(cb); else if (typeof altCb === "function") {
+        if (cb instanceof store.Error) {
+            store.error.callbacks.trigger(cb);
+        } else if (typeof cb === "function") {
+            store.error.callbacks.push(cb);
+        } else if (typeof altCb === "function") {
             ret = function(err) {
                 if (err.code === cb) altCb();
             };
             store.error(ret);
+        } else if (cb.code && cb.message) {
+            store.error.callbacks.trigger(new store.Error(cb));
+        } else if (cb.code) {
+            store.error.callbacks.trigger(new store.Error(cb));
         }
         return ret;
     };


### PR DESCRIPTION
This enables IAP for non-renewable subscriptions in iOS. You use them just like consumable IAP's. The UI is slightly different as is described in Apple docs. You must manage the subscription time period and sync across devices. See Apple doc here https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Products.html#//apple_ref/doc/uid/TP40008267-CH2-SW5

Use type `store.NON_RENEWING_SUBSCRIPTION` when registering a product.