### PR TITLE
Changes to v6.0.0

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -468,7 +468,12 @@ unsigned char* unbase64( const char* ascii, int len, int *flen )
                 if (!transactionIdentifier)
                     transactionIdentifier = transaction.originalTransaction.transactionIdentifier;
                 transactionReceipt = [[transaction transactionReceipt] base64EncodedStringWithOptions:0];
-                productId = transaction.originalTransaction.payment.productIdentifier;
+                // TH 08/03/2016: default to transaction.payment.productIdentifier and use transaction.originalTransaction.payment.productIdentifier as a fallback.
+                // Previously only used transaction.originalTransaction.payment.productIdentifier.
+                // When restoring transactions when there are unfinished transactions, I encountered transactions for which originalTransaction is nil, leading to a nil productId.
+                productId = transaction.payment.productIdentifier;
+                if (!productId)
+                    productId = transaction.originalTransaction.payment.productIdentifier;
                 downloads = transaction.downloads;
                 canFinish = YES;
                 break;

--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -389,6 +389,23 @@ function storekitError(errorCode, errorText, options) {
         return;
     }
 
+    // TH 08/03/2016: Treat errors like cancellations:
+    // - trigger the "error" event on the associated product
+    // - set the product back to the VALID state
+    // This makes it possible to know which product raised an error (previously, errors only fired on the global error listener, which obscures product id).
+    // It also seems more consistent with the documented API. See https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#events and https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#notes
+    p = store.get(options.productId);
+    if (p) {
+        p.trigger("error", [new store.Error({
+            code:    errorCode,
+            message: errorText
+        }), p]);
+        p.set({
+            transaction: null,
+            state: store.VALID
+        });
+    }
+
     store.error({
         code:    errorCode,
         message: errorText

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -2945,6 +2945,23 @@ function storekitError(errorCode, errorText, options) {
         return;
     }
 
+    // TH 08/03/2016: Treat errors like cancellations:
+    // - trigger the "error" event on the associated product
+    // - set the product back to the VALID state
+    // This makes it possible to know which product raised an error (previously, errors only fired on the global error listener, which obscures product id).
+    // It also seems more consistent with the documented API. See https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#events and https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#notes
+    p = store.get(options.productId);
+    if (p) {
+        p.trigger("error", [new store.Error({
+            code:    errorCode,
+            message: errorText
+        }), p]);
+        p.set({
+            transaction: null,
+            state: store.VALID
+        });
+    }
+
     store.error({
         code:    errorCode,
         message: errorText

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -2616,11 +2616,17 @@ store.when("finished", function(product) {
 
 function storekitFinish(product) {
     if (product.type === store.CONSUMABLE || product.type === store.NON_RENEWING_SUBSCRIPTION) {
-        if (product.transaction && product.transaction.id) {
-            storekit.finish(product.transaction.id);
-        }
-        else if (storekit.transactionForProduct[product.id]) {
-            storekit.finish(storekit.transactionForProduct[product.id]);
+        var transactionId = (product.transaction && product.transaction.id) || storekit.transactionForProduct[product.id];
+        if (transactionId) {
+            storekit.finish(transactionId);
+            // TH 08/03/2016: Remove the finished transaction from product.transactions.
+            // Previously didn't clear transactions for these product types on finish.
+            // storekitPurchased suppresses approved events for transactions in product.transactions,
+            // so this prevented the approved event from firing when re-purchasing a product for which finish failed.
+            if (product.transactions) {
+                var idx = product.transactions.indexOf(transactionId);
+                if (idx >= 0) product.transactions.splice(idx, 1);
+            }
         }
         else {
             store.log.debug("ios -> error: unable to find transaction for " + product.id);


### PR DESCRIPTION
Addresses three issues I encountered on iOS:

1. Trigger product's error listener on store errors.

    Currently, most errors (including purchase errors) only fire on the global store.error listener. This obscures which product caused the error.

    NOTE: It looks like the same issue may apply to Android and Windows, although I haven't tested on those platforms yet. This request currently only covers iOS.

2. When finishing consumables and non-renewing subscriptions, clear transactions from product.transactions after calling finish.

    Otherwise, transactions stay in product.transactions indefinitely, preventing future approved events for those transactions. This can come up if finish fails (e.g. due to network error).

3. In InAppPurchase.m, handle restored transactions that have a nil originalTransaction.

    I occasionally encountered these during testing, leading to a nil productId and missing events downstream.
