### PR TITLE
Preventing crash on java.lang.NullPointerException

### DIFF
--- a/src/android/com/smartmobilesoftware/util/IabHelper.java
+++ b/src/android/com/smartmobilesoftware/util/IabHelper.java
@@ -594,6 +594,9 @@ public class IabHelper {
         catch (JSONException e) {
             throw new IabException(ERR_BAD_RESPONSE, "Error parsing JSON response while refreshing inventory.", e);
         }
+        catch (NullPointerException e) {
+            throw new IabException(ERR_UNKNOWN, "NullPointer while refreshing inventory.", e);
+        }
     }
 
     /**
@@ -825,7 +828,7 @@ public class IabHelper {
     }
 
 
-    int queryPurchases(Inventory inv, String itemType) throws JSONException, RemoteException {
+    int queryPurchases(Inventory inv, String itemType) throws JSONException, RemoteException, NullPointerException {
         // Query purchases
         logDebug("Querying owned items, item type: " + itemType);
         logDebug("Package name: " + mContext.getPackageName());


### PR DESCRIPTION
Preventing crash when this error occurs:

com.smartmobilesoftware.util.IabHelper.queryPurchases (IabHelper.java:831)
com.smartmobilesoftware.util.IabHelper.queryInventory (IabHelper.java:576)
com.smartmobilesoftware.util.IabHelper.queryInventory (IabHelper.java:540)
com.smartmobilesoftware.util.IabHelper$2.run (IabHelper.java:635)
java.lang.Thread.run (Thread.java:818)