### PR TITLE
Extend additionalData usage, add developer payload

### DIFF
--- a/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
+++ b/src/android/com/smartmobilesoftware/inappbilling/InAppBillingPlugin.java
@@ -75,24 +75,40 @@ public class InAppBillingPlugin extends CordovaPlugin {
 				// Buy an item
 				// Get Product Id
 				final String sku = data.getString(0);
-				buy(sku);
+				final JSONObject additionalData = data.getJSONObject(1);
+
+				// Get the developer payload
+				String developerPayload = "";
+				if(additionalData.has("developerPayload")) {
+					developerPayload = additionalData.getString("developerPayload");
+				}
+				buy(sku, developerPayload);
 			} else if ("subscribe".equals(action)) {
 				// Subscribe to an item
 				// Get Product Id
 				final String sku = data.getString(0);
+				final JSONObject additionalData = data.getJSONObject(1);
+
+				// Get the developer payload
+				String developerPayload = "";
+				if(additionalData.has("developerPayload")) {
+					developerPayload = additionalData.getString("developerPayload");
+				}
+
+				// Get the subscriptions SKUs to upgrade
 				final List<String> oldPurchasedSkus = new ArrayList<String>();
-				String oldSkuList = data.getString(1);
-				oldSkuList = (oldSkuList == "null")?null:oldSkuList;
-                if (oldSkuList != null){
+				if(additionalData.has("oldPurchasedSkus")) {
+					String oldSkuList = additionalData.getString("oldPurchasedSkus");
 					JSONArray jsonOldSkuList = new JSONArray(oldSkuList);
+
 					int len = jsonOldSkuList.length();
 					Log.d(TAG, "Num old SKUs Found: "+len);
 					for (int i=0;i<len;i++){
 						oldPurchasedSkus.add(jsonOldSkuList.get(i).toString());
 						Log.d(TAG, "Subscription SKU Added: "+jsonOldSkuList.get(i).toString());
 					}
-                }
-           		subscribe(sku, oldPurchasedSkus);
+				}
+				subscribe(sku, developerPayload, oldPurchasedSkus);
 			} else if ("consumePurchase".equals(action)) {
 				consumePurchase(data);
 			} else if ("getAvailableProducts".equals(action)) {
@@ -193,7 +209,7 @@ public class InAppBillingPlugin extends CordovaPlugin {
     }
 
 	// Buy an item
-	private void buy(final String sku){
+	private void buy(final String sku, final String developerPayload){
 		/* TODO: for security, generate your payload here for verification. See the comments on
          *        verifyDeveloperPayload() for more info. Since this is a sample, we just use
          *        an empty string, but on a production app you should generate this. */
@@ -207,12 +223,12 @@ public class InAppBillingPlugin extends CordovaPlugin {
 		this.cordova.setActivityResultCallback(this);
 
 		mHelper.launchPurchaseFlow(cordova.getActivity(), sku, RC_REQUEST,
-                mPurchaseFinishedListener, payload);
+                mPurchaseFinishedListener, developerPayload);
 
 	}
 
 	// Buy an item
-	private void subscribe(final String sku, final List<String> oldPurchasedSkus){
+	private void subscribe(final String sku, final String developerPayload, final List<String> oldPurchasedSkus){
 		if (mHelper == null){
 			callbackContext.error(IabHelper.ERR_PURCHASE + "|Billing plugin was not initialized");
 			return;
@@ -232,7 +248,7 @@ public class InAppBillingPlugin extends CordovaPlugin {
 		this.cordova.setActivityResultCallback(this);
         Log.d(TAG, "Launching purchase flow for subscription.");
 
-		mHelper.launchPurchaseFlow(cordova.getActivity(), sku, IabHelper.ITEM_TYPE_SUBS, oldPurchasedSkus, RC_REQUEST, mPurchaseFinishedListener, payload);
+		mHelper.launchPurchaseFlow(cordova.getActivity(), sku, IabHelper.ITEM_TYPE_SUBS, oldPurchasedSkus, RC_REQUEST, mPurchaseFinishedListener, developerPayload);
 	}
 
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -42,7 +42,7 @@ var ERROR_CODES_BASE = 6777000;
 /*///*/     store.ERR_REFRESH             = ERROR_CODES_BASE + 19; // Failed to refresh the store.
 /*///*/     store.ERR_PAYMENT_EXPIRED     = ERROR_CODES_BASE + 20;
 /*///*/     store.ERR_DOWNLOAD            = ERROR_CODES_BASE + 21;
-    /*///*/     store.ERR_SUBSCRIPTION_UPDATE_NOT_AVAILABLE = ERROR_CODES_BASE + 22;
+/*///*/     store.ERR_SUBSCRIPTION_UPDATE_NOT_AVAILABLE = ERROR_CODES_BASE + 22;
 
 ///
 /// ### product states

--- a/src/js/order.js
+++ b/src/js/order.js
@@ -21,6 +21,7 @@ var callbackId = 0;
 /// The `additionalData` argument can be either:
 ///  - null
 ///  - object with attribute `oldPurchasedSkus`, a string array with the old subscription to upgrade/downgrade on Android. See: [android developer](https://developer.android.com/google/play/billing/billing_reference.html#upgrade-getBuyIntentToReplaceSkus) for more info
+///  - object with attribute `developerPayload`, string representing the developer payload as described in [billing best practices](https://developer.android.com/google/play/billing/billing_best_practices.html)
 ///
 /// See the ["Purchasing section"](#purchasing) to learn more about
 /// the purchase process.
@@ -35,13 +36,12 @@ store.order = function(pid, additionalData) {
             p = new store.Product({
                 id: pid,
                 loaded: true,
-                valid: false,
-                additionalData: additionalData
+                valid: false
             });
         }
-        else if (additionalData) {
-            p.additionalData = additionalData;
-        }
+    }
+    if (additionalData) {
+     	p.additionalData = additionalData;
     }
 
     var localCallbackId = callbackId++;

--- a/src/js/platforms/plugin-adapter.js
+++ b/src/js/platforms/plugin-adapter.js
@@ -114,9 +114,13 @@ store.when("requested", function(product) {
         product.set("state", store.INITIATED);
 
         var method = 'buy';
+        var additionalData = null;
         if (product.type === store.FREE_SUBSCRIPTION || product.type === store.PAID_SUBSCRIPTION) {
             method = 'subscribe';
+            additionalData = (product && product.additionalData && product.additionalData.oldPurchasedSkus)?
+                product.additionalData.oldPurchasedSkus:null;
         }
+
         store.inappbilling[method](function(data) {
             // Success callabck.
             //
@@ -153,7 +157,7 @@ store.when("requested", function(product) {
             else {
                 product.set("state", store.VALID);
             }
-        }, product.id);
+        }, product.id, additionalData);
     });
 });
 

--- a/src/js/platforms/plugin-adapter.js
+++ b/src/js/platforms/plugin-adapter.js
@@ -114,11 +114,8 @@ store.when("requested", function(product) {
         product.set("state", store.INITIATED);
 
         var method = 'buy';
-        var additionalData = null;
         if (product.type === store.FREE_SUBSCRIPTION || product.type === store.PAID_SUBSCRIPTION) {
             method = 'subscribe';
-            additionalData = (product && product.additionalData && product.additionalData.oldPurchasedSkus)?
-                product.additionalData.oldPurchasedSkus:null;
         }
 
         store.inappbilling[method](function(data) {
@@ -157,7 +154,7 @@ store.when("requested", function(product) {
             else {
                 product.set("state", store.VALID);
             }
-        }, product.id, additionalData);
+        }, product.id, product.additionalData);
     });
 });
 

--- a/src/js/platforms/plugin-bridge.js
+++ b/src/js/platforms/plugin-bridge.js
@@ -69,11 +69,31 @@ InAppBilling.prototype.buy = function (success, fail, productId) {
 	}
 	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "buy", [productId]);
 };
-InAppBilling.prototype.subscribe = function (success, fail, productId) {
+InAppBilling.prototype.subscribe = function (success, fail, productId, oldPurchasedSkus) {
 	if (this.options.showLog) {
 		log('subscribe called!');
 	}
-	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId]);
+
+	if (typeof oldPurchasedSkus === "string") {
+		oldPurchasedSkus = [oldPurchasedSkus];
+	}
+	if (!oldPurchasedSkus || !(oldPurchasedSkus.length > 0)) {
+		log('subsribing with no old SKUS!');
+		// Empty array, subscribe with array as null.
+		return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, null]);
+	} else {
+		log('subsribing with existing old SKUS!');
+		if (typeof oldPurchasedSkus[0] !== 'string') {
+			var msg = 'invalid subscription productIds: ' + JSON.stringify(oldPurchasedSkus);
+			log(msg);
+			fail(msg, store.ERR_INVALID_PRODUCT_ID);
+			return;
+		}
+		if (this.options.showLog) {
+			log('load ' + JSON.stringify(oldPurchasedSkus));
+		}
+		return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, oldPurchasedSkus]);
+	}
 };
 InAppBilling.prototype.consumePurchase = function (success, fail, productId, transactionId) {
 	if (this.options.showLog) {

--- a/src/js/platforms/plugin-bridge.js
+++ b/src/js/platforms/plugin-bridge.js
@@ -63,43 +63,22 @@ InAppBilling.prototype.getPurchases = function (success, fail) {
 	}
 	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "getPurchases", ["null"]);
 };
-InAppBilling.prototype.buy = function (success, fail, productId) {
+InAppBilling.prototype.buy = function (success, fail, productId, additionalData) {
 	if (this.options.showLog) {
 		log('buy called!');
 	}
-	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "buy", [productId]);
+	additionalData = (!!additionalData) && (additionalData.constructor === Object) ? additionalData : {};
+	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "buy", [productId, additionalData]);
 };
-InAppBilling.prototype.subscribe = function (success, fail, productId, oldPurchasedSkus) {
+InAppBilling.prototype.subscribe = function (success, fail, productId, additionalData) {
 	if (this.options.showLog) {
 		log('subscribe called!');
 	}
-
-	if (typeof oldPurchasedSkus === "string") {
-		oldPurchasedSkus = [oldPurchasedSkus];
-	}
-	if (!oldPurchasedSkus || !(oldPurchasedSkus.length > 0)) {
-		if (this.options.showLog) {
-			log('subsribing with no old SKUS!');
-		}
-		// Empty array, subscribe with array as null.
-		return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, null]);
-	} else {
-		if (this.options.showLog) {
-			log('subsribing with existing old SKUS!');
-		}
-		if (typeof oldPurchasedSkus[0] !== 'string') {
-			var msg = 'invalid subscription productIds: ' + JSON.stringify(oldPurchasedSkus);
-			if (this.options.showLog) {
-				log(msg);
-			}
-			fail(msg, store.ERR_INVALID_PRODUCT_ID);
-			return;
-		}
-		if (this.options.showLog) {
-			log('load ' + JSON.stringify(oldPurchasedSkus));
-		}
-		return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, oldPurchasedSkus]);
-	}
+	additionalData = (!!additionalData) && (additionalData.constructor === Object) ? additionalData : {};
+	if (additionalData.oldPurchasedSkus && this.options.showLog) {
+    	log('subscribe called with upgrading of old SKUs!);
+    }
+	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, additionalData || {}]);
 };
 InAppBilling.prototype.consumePurchase = function (success, fail, productId, transactionId) {
 	if (this.options.showLog) {

--- a/src/js/platforms/plugin-bridge.js
+++ b/src/js/platforms/plugin-bridge.js
@@ -76,7 +76,7 @@ InAppBilling.prototype.subscribe = function (success, fail, productId, additiona
 	}
 	additionalData = (!!additionalData) && (additionalData.constructor === Object) ? additionalData : {};
 	if (additionalData.oldPurchasedSkus && this.options.showLog) {
-    	log('subscribe called with upgrading of old SKUs!);
+    	log('subscribe called with upgrading of old SKUs!');
     }
 	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, additionalData || {}]);
 };

--- a/src/js/platforms/plugin-bridge.js
+++ b/src/js/platforms/plugin-bridge.js
@@ -78,14 +78,20 @@ InAppBilling.prototype.subscribe = function (success, fail, productId, oldPurcha
 		oldPurchasedSkus = [oldPurchasedSkus];
 	}
 	if (!oldPurchasedSkus || !(oldPurchasedSkus.length > 0)) {
-		log('subsribing with no old SKUS!');
+		if (this.options.showLog) {
+			log('subsribing with no old SKUS!');
+		}
 		// Empty array, subscribe with array as null.
 		return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, null]);
 	} else {
-		log('subsribing with existing old SKUS!');
+		if (this.options.showLog) {
+			log('subsribing with existing old SKUS!');
+		}
 		if (typeof oldPurchasedSkus[0] !== 'string') {
 			var msg = 'invalid subscription productIds: ' + JSON.stringify(oldPurchasedSkus);
-			log(msg);
+			if (this.options.showLog) {
+				log(msg);
+			}
 			fail(msg, store.ERR_INVALID_PRODUCT_ID);
 			return;
 		}

--- a/src/js/product.js
+++ b/src/js/product.js
@@ -76,11 +76,11 @@ store.Product = function(options) {
     ///  - `product.downloaded` - Non-consumable content has been successfully downloaded for this product
     this.downloaded = options.downloaded;
 
+    ///  - `product.additionalData` - additional data possibly required for product purchase
+    this.additionalData = options.additionalData || null;
+
     ///  - `product.transaction` - Latest transaction data for this product (see [transactions](#transactions)).
     this.transaction = null;
-
-    ///  - `product.additionalData` - additional data possibly required for passing info in event based behavior.
-    this.additionalData = null;
 
     this.stateChanged();
 };

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -2072,7 +2072,7 @@ InAppBilling.prototype.subscribe = function (success, fail, productId, additiona
 	}
 	additionalData = (!!additionalData) && (additionalData.constructor === Object) ? additionalData : {};
 	if (additionalData.oldPurchasedSkus && this.options.showLog) {
-		log('subscribe called with upgrading of old SKUs!);
+		log('subscribe called with upgrading of old SKUs!');
 	}
 	return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, additionalData || {}]);
 };

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -2077,14 +2077,20 @@ InAppBilling.prototype.subscribe = function (success, fail, productId, oldPurcha
 		oldPurchasedSkus = [oldPurchasedSkus];
 	}
 	if (!oldPurchasedSkus || !(oldPurchasedSkus.length > 0)) {
-		log('subsribing with no old SKUS!');
+		if (this.options.showLog) {
+			log('subsribing with no old SKUS!');
+		}
 		// Empty array, subscribe with array as null.
 		return cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "subscribe", [productId, null]);
 	} else {
-		log('subsribing with existing old SKUS!');
+		if (this.options.showLog) {
+			log('subsribing with existing old SKUS!');
+		}
 		if (typeof oldPurchasedSkus[0] !== 'string') {
 			var msg = 'invalid subscription productIds: ' + JSON.stringify(oldPurchasedSkus);
-			log(msg);
+			if (this.options.showLog) {
+				log(msg);
+			}
 			fail(msg, store.ERR_INVALID_PRODUCT_ID);
 			return;
 		}

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -349,7 +349,7 @@ var ERROR_CODES_BASE = 6777000;
 /*///*/     store.ERR_REFRESH             = ERROR_CODES_BASE + 19; // Failed to refresh the store.
 /*///*/     store.ERR_PAYMENT_EXPIRED     = ERROR_CODES_BASE + 20;
 /*///*/     store.ERR_DOWNLOAD            = ERROR_CODES_BASE + 21;
-    /*///*/     store.ERR_SUBSCRIPTION_UPDATE_NOT_AVAILABLE = ERROR_CODES_BASE + 22;
+/*///*/     store.ERR_SUBSCRIPTION_UPDATE_NOT_AVAILABLE = ERROR_CODES_BASE + 22;
 
 ///
 /// ### product states


### PR DESCRIPTION
Hi, here's an example of extending the use of additionalData. I rely on the developerPayload option and I need it to be sent from javascript. So I used the additionalData parameter to do this.

  This pull request is based on my previous pull request.