### PR TITLE
Added price_amount_micros to product data

### DIFF
--- a/src/js/platforms/plugin-adapter.js
+++ b/src/js/platforms/plugin-adapter.js
@@ -75,6 +75,7 @@ function iabLoaded(validProducts) {
             p.set({
                 title: validProducts[i].title || validProducts[i].name,
                 price: validProducts[i].price || validProducts[i].formattedPrice,
+                priceMicros: validProducts[i].price_amount_micros,
                 description: validProducts[i].description,
                 currency: validProducts[i].price_currency_code ? validProducts[i].price_currency_code : "",
                 state: store.VALID

--- a/src/js/product.js
+++ b/src/js/product.js
@@ -43,6 +43,9 @@ store.Product = function(options) {
     ///  - `product.description` - Localized longer description
     this.description = options.description || options.localizedDescription || null;
 
+    /// - `product.priceMicros` - Localized price, in micro-units. Available only on Android
+    this.priceMicros = options.priceMicros || null;
+
     ///  - `product.price` - Localized price, with currency symbol
     this.price = options.price || null;
 

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -430,6 +430,9 @@ store.Product = function(options) {
     ///  - `product.price` - Localized price, with currency symbol
     this.price = options.price || null;
 
+    /// - `product.priceMicros` - Localized price, in micro-units. Available only on Android
+    this.priceMicros = options.priceMicros || null;
+
     ///  - `product.currency` - Currency code (optionaly)
     this.currency = options.currency || null;
 
@@ -2229,6 +2232,7 @@ function iabLoaded(validProducts) {
             p.set({
                 title: validProducts[i].title || validProducts[i].name,
                 price: validProducts[i].price || validProducts[i].formattedPrice,
+                priceMicros: validProducts[i].price_amount_micros,
                 description: validProducts[i].description,
                 currency: validProducts[i].price_currency_code ? validProducts[i].price_currency_code : "",
                 state: store.VALID


### PR DESCRIPTION
Recreated, sorry.

My main usage for this is calculating the per month price for subscriptions. Having a float number of the price, regardless of currency and locale makes it really easy and clean to do it.

Might be useful for others, me included. Reference in Table 2 https://developer.android.com/google/play/billing/billing_reference.html