### PR TITLE
Fixing multiple auto-renew subscriptions in IOS

### DIFF
--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -3075,6 +3075,7 @@ store._refreshForValidation = function(callback) {
 store._prepareForValidation = function(product, callback) {
     var nRetry = 0;
     function loadReceipts() {
+	storekit.setAppStoreReceipt(null);
         storekit.loadReceipts(function(r) {
             if (!product.transaction) {
                 product.transaction = {


### PR DESCRIPTION
Solution taken from:
http://stackoverflow.com/questions/33165384/iap-in-hybrid-app-cordova-itunes-receipt-contains-only-the-first-transaction


Scenario (in iOS):
1. Purchase a subscription
2. Upgrade to another subscription

Result (bug):
Apple's receipt validation process with the appStoreReceipt returns for each purchase the same receipt, causing them both to be valid or invalid.

Expected result (after fix):
Every purchase validation receives a different appStoreReceipt to validate which gives different results.