### PR TITLE
(ios) Add store.manageSubscriptions()

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -794,6 +794,19 @@ To make the restore purchases work as expected, please make sure that
 the "approved" event listener had be registered properly,
 and in the callback `product.finish()` should be called.
 
+
+## <a name="refresh"></a>*store.manageSubscriptions()*
+
+(iOS only)
+
+Opens the Manage Subscription page in iTunes.
+
+##### example usage
+
+```js
+   store.manageSubscriptions();
+```
+
 ## *store.log* object
 ### `store.log.error(message)`
 Logs an error message, only if `store.verbosity` >= store.ERROR

--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -177,6 +177,13 @@ static NSString *jsErrorCodeAsString(NSInteger code) {
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+-(void) manageSubscriptions: (CDVInvokedUrlCommand*)command {
+    NSURL *URL = [NSURL URLWithString:@"https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"];
+    [[UIApplication sharedApplication] openURL:URL options:@{} completionHandler:nil];
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"manageSubscriptions"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 /**
  * Request product data for the given productIds.
  * See js for further documentation.

--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -420,6 +420,10 @@ function storekitError(errorCode, errorText, options) {
     });
 }
 
+store.manageSubscriptions = function() {
+    storekit.manageSubscriptions();
+};
+
 // Restore purchases.
 // store.restore = function() {
 // };

--- a/src/js/platforms/ios-bridge.js
+++ b/src/js/platforms/ios-bridge.js
@@ -173,6 +173,10 @@ InAppPurchase.prototype.restore = function() {
     exec('restoreCompletedTransactions', []);
 };
 
+InAppPurchase.prototype.manageSubscriptions = function () {
+    exec('manageSubscriptions', []);
+};
+
 /*
  * Requests all active downloads be paused
  */

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -304,6 +304,20 @@ store.sandbox = false;
 // #include "validator.js"
 // #include "refresh.js"
 
+///
+/// ## <a name="refresh"></a>*store.manageSubscriptions()*
+///
+/// (iOS only)
+///
+/// Opens the Manage Subscription page in iTunes.
+///
+/// ##### example usage
+///
+/// ```js
+///    store.manageSubscriptions();
+/// ```
+///
+
 // #include "log.js"
 
 /// # Random Tips

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -1477,6 +1477,20 @@ store.refresh = function() {
 
 })();
 
+///
+/// ## <a name="refresh"></a>*store.manageSubscriptions()*
+///
+/// (iOS only)
+///
+/// Opens the Manage Subscription page in iTunes.
+///
+/// ##### example usage
+///
+/// ```js
+///    store.manageSubscriptions();
+/// ```
+///
+
 (function(){
 "use strict";
 

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1498,6 +1498,20 @@ store.refresh = function() {
 
 })();
 
+///
+/// ## <a name="refresh"></a>*store.manageSubscriptions()*
+///
+/// (iOS only)
+///
+/// Opens the Manage Subscription page in iTunes.
+///
+/// ##### example usage
+///
+/// ```js
+///    store.manageSubscriptions();
+/// ```
+///
+
 (function(){
 "use strict";
 
@@ -2206,6 +2220,10 @@ InAppPurchase.prototype.canMakePayments = function(success, error){
 InAppPurchase.prototype.restore = function() {
     this.needRestoreNotification = true;
     exec('restoreCompletedTransactions', []);
+};
+
+InAppPurchase.prototype.manageSubscriptions = function () {
+    exec('manageSubscriptions', []);
 };
 
 /*
@@ -3005,6 +3023,10 @@ function storekitError(errorCode, errorText, options) {
         message: errorText
     });
 }
+
+store.manageSubscriptions = function() {
+    storekit.manageSubscriptions();
+};
 
 // Restore purchases.
 // store.restore = function() {

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -1477,6 +1477,20 @@ store.refresh = function() {
 
 })();
 
+///
+/// ## <a name="refresh"></a>*store.manageSubscriptions()*
+///
+/// (iOS only)
+///
+/// Opens the Manage Subscription page in iTunes.
+///
+/// ##### example usage
+///
+/// ```js
+///    store.manageSubscriptions();
+/// ```
+///
+
 (function(){
 "use strict";
 


### PR DESCRIPTION
Opens iTunes' subscription management section.

Ref: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Subscriptions.html#//apple_ref/doc/uid/TP40008267-CH7-SW5

    Enabling Users to Manage Subscriptions

    Rather than implementing your own subscription management UI, your
    app can open the following URL:

    https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions

    Opening this URL launches iTunes or iTunes Store and displays the
    Manage Subscription page.