### PR TITLE
(android) Backport NullPointer crash fix

### DIFF
--- a/src/android/com/smartmobilesoftware/util/IabHelper.java
+++ b/src/android/com/smartmobilesoftware/util/IabHelper.java
@@ -953,6 +953,11 @@ public class IabHelper {
             return BILLING_RESPONSE_RESULT_OK;
         }
 
+        // NullPointer crash reported through PlayStore forums
+        if (mService == null) {
+          return ERR_UNKNOWN;
+        }
+
         // Split the SKUs into slices of maximum 20 entries before querying them to prevent 
         // "Input Error: skusBundle array associated with key ITEM_ID_LIST cannot contain more than 20 items."
         while (skuList.size() > 0) {


### PR DESCRIPTION
Found out some people added that into their IabHelper here:
https://stackoverflow.com/questions/38131475/inapp-billing-java-lang-securityexception-requires-read-phone-state

I never heard about the bug, but I suppose it should not hurt to add
this check.