### PR TITLE
[WIP] Improve validator calling strategy

### DIFF
--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -508,33 +508,15 @@ store._refreshForValidation = function(callback) {
 
 // Load receipts required by server-side validation of purchases.
 store._prepareForValidation = function(product, callback) {
-    var nRetry = 0;
-    function loadReceipts() {
-        storekit.setAppStoreReceipt(null);
-        storekit.loadReceipts(function(r) {
-            if (!product.transaction) {
-                product.transaction = {
-                    type: 'ios-appstore'
-                };
-            }
-            product.transaction.appStoreReceipt = r.appStoreReceipt;
-            if (product.transaction.id)
-                product.transaction.transactionReceipt = r.forTransaction(product.transaction.id);
-            if (!product.transaction.appStoreReceipt && !product.transaction.transactionReceipt) {
-                nRetry ++;
-                if (nRetry < 2) {
-                    setTimeout(loadReceipts, 500);
-                    return;
-                }
-                else if (nRetry === 2) {
-                    storekit.refreshReceipts(loadReceipts);
-                    return;
-                }
-            }
-            callback();
-        });
-    }
-    loadReceipts();
+    storekit.loadReceipts(function(r) {
+        if (!product.transaction) {
+            product.transaction = {
+                type: 'ios-appstore'
+            };
+        }
+        product.transaction.appStoreReceipt = r.appStoreReceipt;
+    });
+    callback();
 };
 
 //!

--- a/test/js/test-verify.js
+++ b/test/js/test-verify.js
@@ -75,7 +75,7 @@ describe('Verify', function() {
                     assert.equal(1, successCalled, "success should be called");
                     assert.equal(1, doneCalled,    "done should be called");
                     done();
-                }, 1500);
+                }, 3000);
             };
 
             step1();


### PR DESCRIPTION
iOS deprecated the transaction receipt since iOS 6 or something. I guess
we can safely assume we have an app receipt in all cases.

As such, we can greatly optimize the way the required preliminary work
before calling a validator (i.e. load the receipt once and for all
before validating each product).