### PR TITLE
fix: make sure response.data is set

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -160,6 +160,7 @@ store.Product.prototype.verify = function() {
 
         store._validator(that, function(success, data) {
             store.log.debug("verify -> " + JSON.stringify(success));
+            if (!data) data = {};
             if (success) {
                 if (that.expired)
                     that.set("expired", false);
@@ -173,7 +174,6 @@ store.Product.prototype.verify = function() {
             }
             else {
                 store.log.debug("verify -> error: " + JSON.stringify(data));
-                if (!data) data = {};
                 var msg = (data && data.error && data.error.message ? data.error.message : '');
                 var err = new store.Error({
                     code: store.ERR_VERIFICATION_FAILED,

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -544,6 +544,7 @@ store.Product.prototype.verify = function() {
 
         store._validator(that, function(success, data) {
             store.log.debug("verify -> " + JSON.stringify(success));
+            if (!data) data = {};
             if (success) {
                 if (that.expired)
                     that.set("expired", false);
@@ -557,7 +558,6 @@ store.Product.prototype.verify = function() {
             }
             else {
                 store.log.debug("verify -> error: " + JSON.stringify(data));
-                if (!data) data = {};
                 var msg = (data && data.error && data.error.message ? data.error.message : '');
                 var err = new store.Error({
                     code: store.ERR_VERIFICATION_FAILED,

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -565,6 +565,7 @@ store.Product.prototype.verify = function() {
 
         store._validator(that, function(success, data) {
             store.log.debug("verify -> " + JSON.stringify(success));
+            if (!data) data = {};
             if (success) {
                 if (that.expired)
                     that.set("expired", false);
@@ -578,7 +579,6 @@ store.Product.prototype.verify = function() {
             }
             else {
                 store.log.debug("verify -> error: " + JSON.stringify(data));
-                if (!data) data = {};
                 var msg = (data && data.error && data.error.message ? data.error.message : '');
                 var err = new store.Error({
                     code: store.ERR_VERIFICATION_FAILED,

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -544,6 +544,7 @@ store.Product.prototype.verify = function() {
 
         store._validator(that, function(success, data) {
             store.log.debug("verify -> " + JSON.stringify(success));
+            if (!data) data = {};
             if (success) {
                 if (that.expired)
                     that.set("expired", false);
@@ -557,7 +558,6 @@ store.Product.prototype.verify = function() {
             }
             else {
                 store.log.debug("verify -> error: " + JSON.stringify(data));
-                if (!data) data = {};
                 var msg = (data && data.error && data.error.message ? data.error.message : '');
                 var err = new store.Error({
                     code: store.ERR_VERIFICATION_FAILED,


### PR DESCRIPTION
The last update ([`Let receipt validator update product's transaction info`](https://github.com/j3k0/cordova-plugin-purchase/commit/c261c01bdd6f0fff29b0d08fbe5e4a43d3f1c0c7)) expects the validation-servers response to have a `data` field, which is not always the case.

This fix makes sure `data` it is defined.