### PR TITLE
Type definitions: Make store.register alias parameter optional

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -138,7 +138,7 @@ declare namespace IapStore {
 
   export interface IRegisterRequest {
     id: string;
-    alias: string;
+    alias?: string;
     type: StoreProductType;
   }
 


### PR DESCRIPTION
Update alias parameter of store.register method in type definitions to be optional to match actual implementation