### PR TITLE
macos support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,6 +72,9 @@ SOFTWARE.
         <js-module src="www/store-ios.js" name="InAppPurchase">
             <clobbers target="store" />
         </js-module>
+        <js-module src="www/cordova-osx-polyfill.js" name="CordovaOSXPolyfill">
+            <runs />
+        </js-module>        
 
         <!-- Cordova 2.5+ -->
         <config-file target="config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,6 +67,30 @@ SOFTWARE.
         <framework src="StoreKit.framework" />
     </platform>
 
+    <!-- osx -->
+    <platform name="osx">
+        <js-module src="www/store-ios.js" name="InAppPurchase">
+            <clobbers target="store" />
+        </js-module>
+
+        <!-- Cordova 2.5+ -->
+        <config-file target="config.xml" parent="/*">
+            <feature name="InAppPurchase">
+                <param name="osx-package" value="InAppPurchase" />
+                <param name="onload" value="true" />
+            </feature>
+        </config-file>
+
+        <header-file src="src/ios/InAppPurchase.h" />
+        <source-file src="src/ios/InAppPurchase.m" />
+        <header-file src="src/ios/SKProduct+LocalizedPrice.h" />
+        <source-file src="src/ios/SKProduct+LocalizedPrice.m" />
+        <header-file src="src/ios/FileUtility.h" />
+        <source-file src="src/ios/FileUtility.m" />
+
+        <framework src="StoreKit.framework" />
+    </platform>    
+
     <!-- android -->
     <platform name="android">
         <preference name="BILLING_KEY" />

--- a/www/cordova-osx-polyfill.js
+++ b/www/cordova-osx-polyfill.js
@@ -1,0 +1,21 @@
+/**
+ * Workaround for missing nativeEvalAndFetch on cordova-osx
+ * 
+ * This polyfill adds the missing function 'nativeEvalAndFetch' required to run js from the native side
+ * It can be removed when the cordova-osx team implements it.
+ * 
+ * Discussion on this solution: https://github.com/j3k0/cordova-plugin-purchase/pull/848
+ * Cordova-osx issue: https://github.com/apache/cordova-osx/issues/80
+ */
+
+var exec = require('cordova/exec');
+
+if (!exec.nativeEvalAndFetch) {
+    exec.nativeEvalAndFetch = function (f) {
+        try {
+            f();
+        } catch (e) {
+            console.error(e.message || e, e.stack);
+        }
+    };
+}


### PR DESCRIPTION
Hi I added macos support.
I avoided code duplication and, given the StoreKit is the same, with some preprocecessor ifs, I managed to share the same code with the iOS. On the JS side the code is exactly the same. So I linked directly the ios-js.
The only thing is the logs mentioning ios, i.e. "ios --> finishing" ...
I didnt want add logic just for the sake of log labelling, maybe can be changed with some common value "storekit" or "app store".
I tested consumable/non consumable. I don't have an app with subscriptions, so I didn't try them, but the storekit flow is the same, I think they should work fine.
Let me know what you think and if I have to edit something.