### PR TITLE
Add option to disable automatic download of hosted content on iOS.

### DIFF
--- a/doc/ios.md
+++ b/doc/ios.md
@@ -68,6 +68,10 @@ Demo application project
 - Edit [config.xml](https://github.com/dpa99c/cordova-plugin-purchase-demo/blob/master/config.xml) and set the `id` attribute in the `<widget>` element to that of your app Identifier
 - Edit [www/index.js](https://github.com/dpa99c/cordova-plugin-purchase-demo/blob/master/www/js/index.js) and set the `id` fields under `store.register` are for your IAP Identifiers.
 
+You can omit automatic downloading of hosted content by setting the `omitHostedContentDownload` store flag, for example:
+
+    store.omitHostedContentDownload = true;
+    store.refresh();
 
 ### <a name="non-renewing"></a>Non-Renewing iOS Subscriptions
 

--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -14,6 +14,7 @@
 static BOOL g_initialized = NO;
 static BOOL g_debugEnabled = NO;
 static BOOL g_autoFinishEnabled = NO;
+static BOOL g_downloadHostedContent = YES;
 
 /*
  * Helpers
@@ -158,6 +159,10 @@ static NSString *jsErrorCodeAsString(NSInteger code) {
 
 -(void) autoFinish: (CDVInvokedUrlCommand*)command {
     g_autoFinishEnabled = YES;
+}
+
+-(void) omitHostedContentDownload: (CDVInvokedUrlCommand*)command {
+    g_downloadHostedContent = NO;
 }
 
 -(void) setup: (CDVInvokedUrlCommand*)command {
@@ -425,7 +430,7 @@ static NSString *jsErrorCodeAsString(NSInteger code) {
         || state == SKPaymentTransactionStateFailed
         || state == SKPaymentTransactionStatePurchased;
 
-    if (downloads && [downloads count] > 0) {
+    if (downloads && [downloads count] > 0 && g_downloadHostedContent) {
         [[SKPaymentQueue defaultQueue] startDownloads:downloads];
     }
     else if (g_autoFinishEnabled && canFinish) {

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -96,6 +96,7 @@ declare namespace IapStore {
     verbosity: number | boolean;
     validator: string | IValidator;
     autoFinishTransactions: boolean;
+    omitHostedContentDownload: boolean;
 
     error(callback: (err: IError) => void): void;
     get(id: string): IStoreProduct;

--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -161,6 +161,7 @@ function storekitInit() {
     storekit.init({
         debug:    store.verbosity >= store.DEBUG ? true : false,
         autoFinish: store.autoFinishTransactions,
+        omitHostedContentDownload: store.omitHostedContentDownload,
         error:    storekitError,
         purchase: storekitPurchased,
         purchasing: storekitPurchasing,

--- a/src/js/platforms/ios-bridge.js
+++ b/src/js/platforms/ios-bridge.js
@@ -98,6 +98,10 @@ InAppPurchase.prototype.init = function (options, success, error) {
         exec('autoFinish', [], noop, noop);
     }
 
+    if (options.omitHostedContentDownload) {
+        exec('omitHostedContentDownload', [], noop, noop);
+    }
+
     var that = this;
     var setupOk = function () {
         log('setup ok');

--- a/test/src/js/iap.js
+++ b/test/src/js/iap.js
@@ -16,6 +16,7 @@
         storekit.init({
             debug:    true,
             noAutoFinish: true,
+            omitHostedContentDownload: false,
             ready:    IAP.onReady,
             purchase: IAP.onPurchase,
             finish:   IAP.onFinish,

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -2287,6 +2287,10 @@ InAppPurchase.prototype.init = function (options, success, error) {
         exec('autoFinish', [], noop, noop);
     }
 
+    if (options.omitHostedContentDownload) {
+        exec('omitHostedContentDownload', [], noop, noop);
+    }
+
     var that = this;
     var setupOk = function () {
         log('setup ok');
@@ -2902,6 +2906,7 @@ function storekitInit() {
     storekit.init({
         debug:    store.verbosity >= store.DEBUG ? true : false,
         autoFinish: store.autoFinishTransactions,
+        omitHostedContentDownload: store.omitHostedContentDownload,
         error:    storekitError,
         purchase: storekitPurchased,
         purchasing: storekitPurchasing,


### PR DESCRIPTION
This PR adds an option to disable automatic download of Hosted Content on the iOS platform.

The reason for this is, if like me you want to move away from Apple Hosted Content to self-hosting your own content, there's no way to remove or change an existing Apple IAP product to be non-hosted and therefore the hosted content will currently always be downloaded if it exists, even if you don't want it to be.

This PR adds the `omitHostedContentDownload` option which is specific to the iOS platform, for example:
	
    store.omitHostedContentDownload = true;
    store.refresh();