### PR TITLE
iOS: Return original transaction ID (if it exists) to purchase callback

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -304,12 +304,12 @@ static NSString *jsErrorCodeAsString(NSInteger code) {
 //
 - (void) paymentQueue:(SKPaymentQueue*)queue updatedTransactions:(NSArray*)transactions {
 
-    NSString *state, *error, *transactionIdentifier, *transactionReceipt, *productId;
+    NSString *state, *error, *transactionIdentifier, *originalTransactionIdentifier, *transactionReceipt, *productId;
     NSInteger errorCode;
 
     for (SKPaymentTransaction *transaction in transactions) {
 
-        error = state = transactionIdentifier = transactionReceipt = productId = @"";
+        error = state = transactionIdentifier = originalTransactionIdentifier = transactionReceipt = productId = @"";
         errorCode = 0;
         DLog(@"paymentQueue:updatedTransactions: %@", transaction.payment.productIdentifier);
 
@@ -326,6 +326,9 @@ static NSString *jsErrorCodeAsString(NSInteger code) {
                 transactionIdentifier = transaction.transactionIdentifier;
                 transactionReceipt = [[transaction transactionReceipt] base64EncodedStringWithOptions:0];
                 productId = transaction.payment.productIdentifier;
+                if(transaction.originalTransaction != nil){
+                    originalTransactionIdentifier = transaction.originalTransaction.transactionIdentifier;
+                }
                 break;
 
             case SKPaymentTransactionStateFailed:
@@ -375,6 +378,7 @@ static NSString *jsErrorCodeAsString(NSInteger code) {
             NILABLE(transactionIdentifier),
             NILABLE(productId),
             NILABLE(transactionReceipt),
+            NILABLE(originalTransactionIdentifier),
             nil];
 
         if (g_initialized) {

--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -330,7 +330,7 @@ function storekitPurchasing(productId) {
 //! It will set the product state to `APPROVED` and associates the product
 //! with the order's transaction identifier.
 //!
-function storekitPurchased(transactionId, productId) {
+function storekitPurchased(transactionId, productId, originalTransactionId) {
     store.ready(function() {
         var product = store.get(productId);
         if (!product) {
@@ -354,6 +354,9 @@ function storekitPurchased(transactionId, productId) {
             type: 'ios-appstore',
             id:   transactionId
         };
+        if(originalTransactionId){
+            product.transaction.originalId = originalTransactionId;
+        }
         if (!product.transactions)
             product.transactions = [];
         product.transactions.push(transactionId);

--- a/src/js/platforms/ios-bridge.js
+++ b/src/js/platforms/ios-bridge.js
@@ -334,7 +334,7 @@ InAppPurchase.prototype.processPendingUpdates = function() {
 //
 // Note that it may eventually be called before initialization... unfortunately.
 // In this case, we'll just keep pending updates in a list for later processing.
-InAppPurchase.prototype.updatedTransactionCallback = function (state, errorCode, errorText, transactionIdentifier, productId, transactionReceipt) {
+InAppPurchase.prototype.updatedTransactionCallback = function (state, errorCode, errorText, transactionIdentifier, productId, transactionReceipt, originalTransactionIdentifier) {
 
     if (!initialized) {
         var args = Array.prototype.slice.call(arguments);
@@ -358,7 +358,7 @@ InAppPurchase.prototype.updatedTransactionCallback = function (state, errorCode,
             protectCall(this.options.purchasing, 'options.purchasing', productId);
             return;
 		case "PaymentTransactionStatePurchased":
-            protectCall(this.options.purchase, 'options.purchase', transactionIdentifier, productId);
+            protectCall(this.options.purchase, 'options.purchase', transactionIdentifier, productId, originalTransactionIdentifier);
 			return;
 		case "PaymentTransactionStateFailed":
             protectCall(this.options.error, 'options.error', errorCode, errorText, {

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -2523,7 +2523,7 @@ InAppPurchase.prototype.processPendingUpdates = function() {
 //
 // Note that it may eventually be called before initialization... unfortunately.
 // In this case, we'll just keep pending updates in a list for later processing.
-InAppPurchase.prototype.updatedTransactionCallback = function (state, errorCode, errorText, transactionIdentifier, productId, transactionReceipt) {
+InAppPurchase.prototype.updatedTransactionCallback = function (state, errorCode, errorText, transactionIdentifier, productId, transactionReceipt, originalTransactionIdentifier) {
 
     if (!initialized) {
         var args = Array.prototype.slice.call(arguments);
@@ -2547,7 +2547,7 @@ InAppPurchase.prototype.updatedTransactionCallback = function (state, errorCode,
             protectCall(this.options.purchasing, 'options.purchasing', productId);
             return;
 		case "PaymentTransactionStatePurchased":
-            protectCall(this.options.purchase, 'options.purchase', transactionIdentifier, productId);
+            protectCall(this.options.purchase, 'options.purchase', transactionIdentifier, productId, originalTransactionIdentifier);
 			return;
 		case "PaymentTransactionStateFailed":
             protectCall(this.options.error, 'options.error', errorCode, errorText, {
@@ -3071,7 +3071,7 @@ function storekitPurchasing(productId) {
 //! It will set the product state to `APPROVED` and associates the product
 //! with the order's transaction identifier.
 //!
-function storekitPurchased(transactionId, productId) {
+function storekitPurchased(transactionId, productId, originalTransactionId) {
     store.ready(function() {
         var product = store.get(productId);
         if (!product) {
@@ -3095,6 +3095,9 @@ function storekitPurchased(transactionId, productId) {
             type: 'ios-appstore',
             id:   transactionId
         };
+        if(originalTransactionId){
+            product.transaction.originalId = originalTransactionId;
+        }
         if (!product.transactions)
             product.transactions = [];
         product.transactions.push(transactionId);


### PR DESCRIPTION
This can be used to determine if a non-consumable product has been newly purchased or is already owned and therefore being re-purchased (i.e. redeemed).

See [this commit](https://github.com/dpa99c/cordova-plugin-purchase-demo/commit/3ede057d6f8b2d0913a753938ab72d14bb6ed09e) in [my fork of the demo project](https://github.com/dpa99c/cordova-plugin-purchase-demo) to see how this could be done.