### PR TITLE
[Android] Add "unowned" event type

### DIFF
--- a/src/js/platforms/android-productdata.js
+++ b/src/js/platforms/android-productdata.js
@@ -76,6 +76,15 @@
                         store.setProductData(p, purchase);
                     }
                 }
+
+				//trigger unowned event for registered products without a purchase
+				store.products.forEach(product => {
+					//if product is not licensed
+					if(!product.license.isActive){
+						product.trigger('unowned');
+					}
+				});
+
                 store.ready(true);
                 if (callback) callback();
             },

--- a/src/js/platforms/android-productdata.js
+++ b/src/js/platforms/android-productdata.js
@@ -1,5 +1,5 @@
 (function () {
-    
+
 
     //   {
     //     "purchaseToken":"tokenabc",
@@ -77,13 +77,13 @@
                     }
                 }
 
-				//trigger unowned event for registered products without a purchase
-				store.products.forEach(product => {
-					//if product is not licensed
-					if(!product.license.isActive){
-						product.trigger('unowned');
-					}
-				});
+                //trigger unowned event for registered products without a purchase
+                store.products.forEach(function(product) {
+                    //if product is not licensed
+                    if(!product.license.isActive){
+                        product.trigger('unowned');
+                    }
+                });
 
                 store.ready(true);
                 if (callback) callback();

--- a/src/js/when.js
+++ b/src/js/when.js
@@ -50,6 +50,10 @@ store.when = function(query, once, callback) {
         ///    - The `err` parameter is an [error object](#errors)
         addPromise('error');
 
+        ///  - `unowned(product)`
+        ///    - Called when a product has no transactions
+        addPromise('unowned');
+
         ///  - `approved(product)`
         ///    - Called when a product [order](#order) is approved.
         addPromise('approved');


### PR DESCRIPTION
This triggers an event of type "unowned" when no transactions are returned from the service.

It seems this would only function on Android based on edited files. Unable to properly test for iOS platform to add support on my own.