### PR TITLE
Update InAppPurchase.m

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -183,7 +183,7 @@ static NSString *jsErrorCodeAsString(NSInteger code) {
 }
 
 -(void) manageSubscriptions: (CDVInvokedUrlCommand*)command {
-    NSURL *URL = [NSURL URLWithString:@"https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"];
+    NSURL *URL = [NSURL URLWithString:@"https://apps.apple.com/account/subscriptions"];
 
 #if TARGET_OS_IPHONE
     [[UIApplication sharedApplication] openURL:URL options:@{} completionHandler:nil];


### PR DESCRIPTION
Update ManageSubscription url accordingly to the updated iTunesConnect documentation.
This fixes the issue where Safari was opening before redirecting to the Appstore subscription screen.

https://developer.apple.com/documentation/storekit/in-app_purchase/handling_subscriptions_billing