### PR TITLE
Added a polyfill for Object.assign to support Android < 4.4.

### DIFF
--- a/www/store-android.js
+++ b/www/store-android.js
@@ -402,6 +402,29 @@ var ERROR_CODES_BASE = 6777000;
 })();
 (function() {
 
+// Add a polyfill for Object.assign in case it isn't supported (which is the case
+// on Android < 4.4), see https://github.com/auth0/auth0-cordova/issues/46 for reference
+if (typeof Object.assign != 'function') {
+    Object.assign = function (target, varArgs) {
+        'use strict';
+        if (target == null) {
+            throw new TypeError('Cannot convert undefined or null to object');
+        }
+        var to = Object(target);
+        for (var index = 1; index < arguments.length; index++) {
+            var nextSource = arguments[index];
+
+            if (nextSource != null) {
+                for (var nextKey in nextSource) {
+                    if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                        to[nextKey] = nextSource[nextKey];
+                    }
+                }
+            }
+        }
+        return to;
+    };
+}
 
 function defer(thisArg, cb, delay) {
     setTimeout(function() {


### PR DESCRIPTION
As discussed via email, validation does not work on devices with Android 4.4 or older, because of a javascript error. This error is triggered because the Android browser on those version of Android doesn't have the ```assign``` method on ```Object```. This PR adds a polyfill to store-android.js to deal with this issue. Successfully tested on a real device with Android 4.4.2.