### PR TITLE
(all) store.restore() callbacks

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -950,6 +950,17 @@ have a way to do just that.
 _NOTE:_ It is a required by the Apple AppStore that a "Refresh Purchases"
         button be visible in the UI.
 
+##### return value
+
+This method returns a promise-like object with the following functions:
+
+- `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
+  At this point, all previously owned products should be in the approved state.
+- `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
+  or expired.
+
+In the case of the restore purchases call, you will want to hide any progress bar when the
+`finished` callback is called.
 
 ##### example usage
 
@@ -966,11 +977,20 @@ _NOTE:_ It is a required by the Apple AppStore that a "Refresh Purchases"
 
 Add a "Refresh Purchases" button to call the `store.refresh()` method, like:
 
-`<button onclick="store.refresh()">Restore Purchases</button>`
+```html
+<button onclick="restorePurchases()">Restore Purchases</button>
+```
+
+```js
+function restorePurchases() {
+   showProgress();
+   store.refresh().finished(hideProgress);
+}
+```
 
 To make the restore purchases work as expected, please make sure that
-the "approved" event listener had be registered properly,
-and in the callback `product.finish()` should be called.
+the "approved" event listener had be registered properly
+and, in the callback, `product.finish()` is called after handling.
 
 
 ## <a name="manageSubscriptions"></a>*store.manageSubscriptions()*

--- a/src/js/platforms/plugin-adapter.js
+++ b/src/js/platforms/plugin-adapter.js
@@ -18,7 +18,8 @@ store.when("re-refreshed", function() {
 
 store.update = function(successCb, errorCb) {
     store.iabGetPurchases(function() {
-        successCb();
+        if (successCb)
+            successCb();
     });
 };
 

--- a/src/js/refresh.js
+++ b/src/js/refresh.js
@@ -22,6 +22,17 @@
 /// _NOTE:_ It is a required by the Apple AppStore that a "Refresh Purchases"
 ///         button be visible in the UI.
 ///
+/// ##### return value
+///
+/// This method returns a promise-like object with the following functions:
+///
+/// - `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
+///   At this point, all previously owned products should be in the approved state.
+/// - `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
+///   or expired.
+///
+/// In the case of the restore purchases call, you will want to hide any progress bar when the
+/// `finished` callback is called.
 ///
 /// ##### example usage
 ///
@@ -38,21 +49,77 @@
 ///
 /// Add a "Refresh Purchases" button to call the `store.refresh()` method, like:
 ///
-/// `<button onclick="store.refresh()">Restore Purchases</button>`
+/// ```html
+/// <button onclick="restorePurchases()">Restore Purchases</button>
+/// ```
+///
+/// ```js
+/// function restorePurchases() {
+///    showProgress();
+///    store.refresh().finished(hideProgress);
+/// }
+/// ```
 ///
 /// To make the restore purchases work as expected, please make sure that
-/// the "approved" event listener had be registered properly,
-/// and in the callback `product.finish()` should be called.
+/// the "approved" event listener had be registered properly
+/// and, in the callback, `product.finish()` is called after handling.
 ///
 
 var initialRefresh = true;
 
+function createPromise() {
+    var events = {};
+
+    // refresh-completed is called when all owned products have been
+    // sent to the approved state.
+    store.once("", "refresh-completed", function() {
+        if (events["refresh-completed"]) return;
+        events["refresh-completed"] = true;
+        store.when().updated(checkFinished);
+        checkFinished(); // make sure this is called at least once
+    });
+
+    // trigger the refresh-finished event when no more products are in the
+    // approved state.
+    function checkFinished() {
+        if (events["refresh-finished"]) return;
+        function isApproved(p) { return p.state === store.APPROVED; }
+        if (store.products.filter(isApproved).length === 0) {
+            // done processing
+            store.off(checkFinished);
+            events["refresh-finished"] = true;
+            setTimeout(function() {
+                // if "completed" triggers "finished",
+                // the setTimeout guarantees calling order
+                store.trigger("refresh-finished");
+            }, 100);
+        }
+    }
+
+    return {
+        completed: genPromise("refresh-completed"),
+        finished: genPromise("refresh-finished"),
+    };
+
+    function genPromise(eventName) {
+        return function(cb) {
+            if (events[eventName])
+                cb();
+            else
+                store.once("", eventName, cb);
+            return this;
+        };
+    }
+}
+
 store.refresh = function() {
+
+    var promise = createPromise();
 
     store.trigger("refreshed");
     if (initialRefresh) {
         initialRefresh = false;
-        return;
+        return promise;
     }
 
     store.log.debug("refresh -> checking products state (" + store.products.length + " products)");
@@ -75,7 +142,7 @@ store.refresh = function() {
     }
 
     store.trigger("re-refreshed");
+    return promise;
 };
-
 
 })();

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1927,6 +1927,17 @@ store.update = function() {};
 /// _NOTE:_ It is a required by the Apple AppStore that a "Refresh Purchases"
 ///         button be visible in the UI.
 ///
+/// ##### return value
+///
+/// This method returns a promise-like object with the following functions:
+///
+/// - `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
+///   At this point, all previously owned products should be in the approved state.
+/// - `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
+///   or expired.
+///
+/// In the case of the restore purchases call, you will want to hide any progress bar when the
+/// `finished` callback is called.
 ///
 /// ##### example usage
 ///
@@ -1943,21 +1954,77 @@ store.update = function() {};
 ///
 /// Add a "Refresh Purchases" button to call the `store.refresh()` method, like:
 ///
-/// `<button onclick="store.refresh()">Restore Purchases</button>`
+/// ```html
+/// <button onclick="restorePurchases()">Restore Purchases</button>
+/// ```
+///
+/// ```js
+/// function restorePurchases() {
+///    showProgress();
+///    store.refresh().finished(hideProgress);
+/// }
+/// ```
 ///
 /// To make the restore purchases work as expected, please make sure that
-/// the "approved" event listener had be registered properly,
-/// and in the callback `product.finish()` should be called.
+/// the "approved" event listener had be registered properly
+/// and, in the callback, `product.finish()` is called after handling.
 ///
 
 var initialRefresh = true;
 
+function createPromise() {
+    var events = {};
+
+    // refresh-completed is called when all owned products have been
+    // sent to the approved state.
+    store.once("", "refresh-completed", function() {
+        if (events["refresh-completed"]) return;
+        events["refresh-completed"] = true;
+        store.when().updated(checkFinished);
+        checkFinished(); // make sure this is called at least once
+    });
+
+    // trigger the refresh-finished event when no more products are in the
+    // approved state.
+    function checkFinished() {
+        if (events["refresh-finished"]) return;
+        function isApproved(p) { return p.state === store.APPROVED; }
+        if (store.products.filter(isApproved).length === 0) {
+            // done processing
+            store.off(checkFinished);
+            events["refresh-finished"] = true;
+            setTimeout(function() {
+                // if "completed" triggers "finished",
+                // the setTimeout guarantees calling order
+                store.trigger("refresh-finished");
+            }, 100);
+        }
+    }
+
+    return {
+        completed: genPromise("refresh-completed"),
+        finished: genPromise("refresh-finished"),
+    };
+
+    function genPromise(eventName) {
+        return function(cb) {
+            if (events[eventName])
+                cb();
+            else
+                store.once("", eventName, cb);
+            return this;
+        };
+    }
+}
+
 store.refresh = function() {
+
+    var promise = createPromise();
 
     store.trigger("refreshed");
     if (initialRefresh) {
         initialRefresh = false;
-        return;
+        return promise;
     }
 
     store.log.debug("refresh -> checking products state (" + store.products.length + " products)");
@@ -1980,8 +2047,8 @@ store.refresh = function() {
     }
 
     store.trigger("re-refreshed");
+    return promise;
 };
-
 
 })();
 


### PR DESCRIPTION
With this PR, `store.refresh()` returns a promise-like object with the following functions:

- `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed. At this point, all previously owned products should be in the approved state.
- `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished or expired.

In the case of the restore purchases call, you will want to hide any progress bar when the `finished` callback is called.

Example:

```js
function restorePurchases() {
    showProgress();
    store.refresh().finished(hideProgress);
}
```