### PR TITLE
Refresh `.failed()` and `.cancelled()`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -960,10 +960,12 @@ _NOTE:_ It is a required by the Apple AppStore that a "Refresh Purchases"
 
 This method returns a promise-like object with the following functions:
 
+- `.cancelled(fn)` - Calls `fn` when the user cancelled the refresh request.
+- `.failed(fn)` - Calls `fn` when restoring purchases failed.
 - `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
   At this point, all previously owned products should be in the approved state.
-- `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
-  or expired.
+- `.finished(fn)` - Calls `fn` when the restore is finished, i.e. it has failed, been cancelled,
+  or all purchased in the approved state have been finished or expired.
 
 In the case of the restore purchases call, you will want to hide any progress bar when the
 `finished` callback is called.

--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -597,7 +597,10 @@ function storekitRestoreFailed(errorCode) {
         code: store.ERR_REFRESH,
         message: "Failed to restore purchases during refresh (" + errorCode + ")"
     });
-    store.trigger('refresh-failed');
+    if (errorCode === store.ERR_PAYMENT_CANCELLED)
+        store.trigger('refresh-cancelled');
+    else
+        store.trigger('refresh-failed');
 }
 
 function storekitDownloadActive(transactionIdentifier, productId, progress, timeRemaining) {

--- a/src/js/refresh.js
+++ b/src/js/refresh.js
@@ -26,10 +26,12 @@
 ///
 /// This method returns a promise-like object with the following functions:
 ///
+/// - `.cancelled(fn)` - Calls `fn` when the user cancelled the refresh request.
+/// - `.failed(fn)` - Calls `fn` when restoring purchases failed.
 /// - `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
 ///   At this point, all previously owned products should be in the approved state.
-/// - `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
-///   or expired.
+/// - `.finished(fn)` - Calls `fn` when the restore is finished, i.e. it has failed, been cancelled,
+///   or all purchased in the approved state have been finished or expired.
 ///
 /// In the case of the restore purchases call, you will want to hide any progress bar when the
 /// `finished` callback is called.
@@ -70,16 +72,50 @@ var initialRefresh = true;
 function createPromise() {
     var events = {};
 
-    // refresh-completed is called when all owned products have been
-    // sent to the approved state.
-    store.once("", "refresh-completed", function() {
-        if (events["refresh-completed"]) return;
-        events["refresh-completed"] = true;
-        store.when().updated(checkFinished);
-        checkFinished(); // make sure this is called at least once
-    });
+    // User callbacks for each type of events
+    var callbacks = {
+        "refresh-failed": [],
+        "refresh-cancelled": [],
+        "refresh-completed": [],
+        "refresh-finished": [],
+    };
 
-    // trigger the refresh-finished event when no more products are in the
+    // Setup our own event handlers
+    store.once("", "refresh-failed", failed);
+    store.once("", "refresh-cancelled", cancelled);
+    store.once("", "refresh-completed", completed);
+    store.once("", "refresh-finished", finished);
+
+    // Return the promise object
+    return {
+        cancelled: genPromise("refresh-cancelled"),
+        failed: genPromise("refresh-failed"),
+        completed: genPromise("refresh-completed"),
+        finished: genPromise("refresh-finished"),
+    };
+
+    // A promise function calls the callback or registers it
+    function genPromise(eventName) {
+        return function(cb) {
+            if (events[eventName])
+                cb();
+            else
+                callbacks[eventName].push(cb);
+            return this;
+        };
+    }
+
+    // Call all user callbacks for a given event
+    function callCallbacks(eventName) {
+        callbacks[eventName].forEach(function(cb) { cb(); });
+        callbacks[eventName] = [];
+    }
+    // Delete user callbacks for a given event
+    function deleteCallbacks(eventName) {
+        callbacks[eventName] = [];
+    }
+
+    // Trigger the refresh-finished event when no more products are in the
     // approved state.
     function checkFinished() {
         if (events["refresh-finished"]) return;
@@ -87,29 +123,68 @@ function createPromise() {
         if (store.products.filter(isApproved).length === 0) {
             // done processing
             store.off(checkFinished);
-            events["refresh-finished"] = true;
-            setTimeout(function() {
-                // if "completed" triggers "finished",
-                // the setTimeout guarantees calling order
-                store.trigger("refresh-finished");
-            }, 100);
+            finish();
         }
     }
 
-    return {
-        completed: genPromise("refresh-completed"),
-        finished: genPromise("refresh-finished"),
-    };
-
-    function genPromise(eventName) {
-        return function(cb) {
-            if (events[eventName])
-                cb();
-            else
-                store.once("", eventName, cb);
-            return this;
-        };
+    // Remove base events handlers
+    function off() {
+        store.off(cancelled);
+        store.off(completed);
+        store.off(failed);
     }
+
+    // Fire a base event
+    function fire(eventName) {
+        off();
+        if (events[eventName])
+            return false;
+        events[eventName] = true;
+        ["refresh-cancelled", "refresh-failed", "refresh-completed"]
+        .forEach(function (e) {
+            if (e === eventName)
+                callCallbacks(e);
+            else
+                deleteCallbacks(e);
+        });
+        return true;
+    }
+
+    // Fire the refresh-finished event
+    function finish() {
+        events["refresh-finished"] = true;
+        // setTimeout guarantees calling order
+        setTimeout(function() {
+            store.trigger("refresh-finished");
+        }, 100);
+    }
+
+    // refresh-cancelled called when the user cancelled the password popup
+    function cancelled() {
+        if (fire("refresh-cancelled"))
+            finish();
+    }
+
+    // refresh-cancelled called when restore purchases couldn't complete
+    // (can't connect to store or user not allowed to make purchases)
+    function failed() {
+        if (fire("refresh-failed"))
+            finish();
+    }
+
+    // refresh-completed is called when all owned products have been
+    // sent to the approved state.
+    function completed() {
+        if (fire("refresh-completed")) {
+            store.when().updated(checkFinished);
+            checkFinished(); // make sure this is called at least once
+        }
+    }
+
+    function finished() {
+        callCallbacks("refresh-finished");
+    }
+
 }
 
 store.refresh = function() {

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -1924,10 +1924,12 @@ store.update = function() {};
 ///
 /// This method returns a promise-like object with the following functions:
 ///
+/// - `.cancelled(fn)` - Calls `fn` when the user cancelled the refresh request.
+/// - `.failed(fn)` - Calls `fn` when restoring purchases failed.
 /// - `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
 ///   At this point, all previously owned products should be in the approved state.
-/// - `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
-///   or expired.
+/// - `.finished(fn)` - Calls `fn` when the restore is finished, i.e. it has failed, been cancelled,
+///   or all purchased in the approved state have been finished or expired.
 ///
 /// In the case of the restore purchases call, you will want to hide any progress bar when the
 /// `finished` callback is called.
@@ -1968,16 +1970,48 @@ var initialRefresh = true;
 function createPromise() {
     var events = {};
 
-    // refresh-completed is called when all owned products have been
-    // sent to the approved state.
-    store.once("", "refresh-completed", function() {
-        if (events["refresh-completed"]) return;
-        events["refresh-completed"] = true;
-        store.when().updated(checkFinished);
-        checkFinished(); // make sure this is called at least once
-    });
+    // User callbacks for each type of events
+    var callbacks = {
+        "refresh-failed": [],
+        "refresh-cancelled": [],
+        "refresh-completed": [],
+        "refresh-finished": [],
+    };
 
-    // trigger the refresh-finished event when no more products are in the
+    // Setup our own event handlers
+    store.once("", "refresh-failed", failed);
+    store.once("", "refresh-cancelled", cancelled);
+    store.once("", "refresh-completed", completed);
+    store.once("", "refresh-finished", finished);
+    store.error(error);
+
+    // Return the promise object
+    return {
+        cancelled: genPromise("refresh-cancelled"),
+        failed: genPromise("refresh-failed"),
+        completed: genPromise("refresh-completed"),
+        finished: genPromise("refresh-finished"),
+    };
+
+    // A promise function calls the callback or registers it
+    function genPromise(eventName) {
+        return function(cb) {
+            if (events[eventName])
+                cb();
+            else
+                callbacks[eventName].push(cb);
+            return this;
+        };
+    }
+
+    // Call all user callbacks for a given event
+    function callback(eventName) {
+        callbacks[eventName].forEach(function(cb) { cb(); });
+        callbacks[eventName] = [];
+    }
+
+    // Delete user callbacks for a given event
+    // Trigger the refresh-finished event when no more products are in the
     // approved state.
     function checkFinished() {
         if (events["refresh-finished"]) return;
@@ -1985,29 +2019,69 @@ function createPromise() {
         if (store.products.filter(isApproved).length === 0) {
             // done processing
             store.off(checkFinished);
-            events["refresh-finished"] = true;
-            setTimeout(function() {
-                // if "completed" triggers "finished",
-                // the setTimeout guarantees calling order
-                store.trigger("refresh-finished");
-            }, 100);
+            finish();
         }
     }
 
-    return {
-        completed: genPromise("refresh-completed"),
-        finished: genPromise("refresh-finished"),
-    };
-
-    function genPromise(eventName) {
-        return function(cb) {
-            if (events[eventName])
-                cb();
-            else
-                store.once("", eventName, cb);
-            return this;
-        };
+    // Remove base events handlers
+    function off() {
+        store.off(cancelled);
+        store.off(completed);
+        store.off(failed);
+        store.off(checkFinished);
+        store.off(error);
     }
+
+    // Fire a base event
+    function fire(eventName) {
+        if (events[eventName]) return false;
+        events[eventName] = true;
+        callback(eventName);
+        return true;
+    }
+
+    // Fire the refresh-finished event
+    function finish() {
+        off();
+        if (events["refresh-finished"]) return;
+        events["refresh-finished"] = true;
+        // setTimeout guarantees calling order
+        setTimeout(function() {
+            store.trigger("refresh-finished");
+        }, 100);
+    }
+
+    // refresh-cancelled called when the user cancelled the password popup
+    function cancelled() {
+        fire("refresh-cancelled");
+        finish();
+    }
+
+    // refresh-cancelled called when restore purchases couldn't complete
+    // (can't connect to store or user not allowed to make purchases)
+    function failed() {
+        fire("refresh-failed");
+        finish();
+    }
+
+    function error() {
+        fire("refresh-failed");
+        finish();
+    }
+
+    // refresh-completed is called when all owned products have been
+    // sent to the approved state.
+    function completed() {
+        if (fire("refresh-completed")) {
+            store.when().updated(checkFinished);
+            checkFinished(); // make sure this is called at least once
+        }
+    }
+
+    function finished() {
+        callback("refresh-finished");
+    }
+
 }
 
 store.refresh = function() {

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1945,10 +1945,12 @@ store.update = function() {};
 ///
 /// This method returns a promise-like object with the following functions:
 ///
+/// - `.cancelled(fn)` - Calls `fn` when the user cancelled the refresh request.
+/// - `.failed(fn)` - Calls `fn` when restoring purchases failed.
 /// - `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
 ///   At this point, all previously owned products should be in the approved state.
-/// - `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
-///   or expired.
+/// - `.finished(fn)` - Calls `fn` when the restore is finished, i.e. it has failed, been cancelled,
+///   or all purchased in the approved state have been finished or expired.
 ///
 /// In the case of the restore purchases call, you will want to hide any progress bar when the
 /// `finished` callback is called.
@@ -1989,16 +1991,48 @@ var initialRefresh = true;
 function createPromise() {
     var events = {};
 
-    // refresh-completed is called when all owned products have been
-    // sent to the approved state.
-    store.once("", "refresh-completed", function() {
-        if (events["refresh-completed"]) return;
-        events["refresh-completed"] = true;
-        store.when().updated(checkFinished);
-        checkFinished(); // make sure this is called at least once
-    });
+    // User callbacks for each type of events
+    var callbacks = {
+        "refresh-failed": [],
+        "refresh-cancelled": [],
+        "refresh-completed": [],
+        "refresh-finished": [],
+    };
 
-    // trigger the refresh-finished event when no more products are in the
+    // Setup our own event handlers
+    store.once("", "refresh-failed", failed);
+    store.once("", "refresh-cancelled", cancelled);
+    store.once("", "refresh-completed", completed);
+    store.once("", "refresh-finished", finished);
+    store.error(error);
+
+    // Return the promise object
+    return {
+        cancelled: genPromise("refresh-cancelled"),
+        failed: genPromise("refresh-failed"),
+        completed: genPromise("refresh-completed"),
+        finished: genPromise("refresh-finished"),
+    };
+
+    // A promise function calls the callback or registers it
+    function genPromise(eventName) {
+        return function(cb) {
+            if (events[eventName])
+                cb();
+            else
+                callbacks[eventName].push(cb);
+            return this;
+        };
+    }
+
+    // Call all user callbacks for a given event
+    function callback(eventName) {
+        callbacks[eventName].forEach(function(cb) { cb(); });
+        callbacks[eventName] = [];
+    }
+
+    // Delete user callbacks for a given event
+    // Trigger the refresh-finished event when no more products are in the
     // approved state.
     function checkFinished() {
         if (events["refresh-finished"]) return;
@@ -2006,29 +2040,69 @@ function createPromise() {
         if (store.products.filter(isApproved).length === 0) {
             // done processing
             store.off(checkFinished);
-            events["refresh-finished"] = true;
-            setTimeout(function() {
-                // if "completed" triggers "finished",
-                // the setTimeout guarantees calling order
-                store.trigger("refresh-finished");
-            }, 100);
+            finish();
         }
     }
 
-    return {
-        completed: genPromise("refresh-completed"),
-        finished: genPromise("refresh-finished"),
-    };
-
-    function genPromise(eventName) {
-        return function(cb) {
-            if (events[eventName])
-                cb();
-            else
-                store.once("", eventName, cb);
-            return this;
-        };
+    // Remove base events handlers
+    function off() {
+        store.off(cancelled);
+        store.off(completed);
+        store.off(failed);
+        store.off(checkFinished);
+        store.off(error);
     }
+
+    // Fire a base event
+    function fire(eventName) {
+        if (events[eventName]) return false;
+        events[eventName] = true;
+        callback(eventName);
+        return true;
+    }
+
+    // Fire the refresh-finished event
+    function finish() {
+        off();
+        if (events["refresh-finished"]) return;
+        events["refresh-finished"] = true;
+        // setTimeout guarantees calling order
+        setTimeout(function() {
+            store.trigger("refresh-finished");
+        }, 100);
+    }
+
+    // refresh-cancelled called when the user cancelled the password popup
+    function cancelled() {
+        fire("refresh-cancelled");
+        finish();
+    }
+
+    // refresh-cancelled called when restore purchases couldn't complete
+    // (can't connect to store or user not allowed to make purchases)
+    function failed() {
+        fire("refresh-failed");
+        finish();
+    }
+
+    function error() {
+        fire("refresh-failed");
+        finish();
+    }
+
+    // refresh-completed is called when all owned products have been
+    // sent to the approved state.
+    function completed() {
+        if (fire("refresh-completed")) {
+            store.when().updated(checkFinished);
+            checkFinished(); // make sure this is called at least once
+        }
+    }
+
+    function finished() {
+        callback("refresh-finished");
+    }
+
 }
 
 store.refresh = function() {
@@ -3985,7 +4059,10 @@ function storekitRestoreFailed(errorCode) {
         code: store.ERR_REFRESH,
         message: "Failed to restore purchases during refresh (" + errorCode + ")"
     });
-    store.trigger('refresh-failed');
+    if (errorCode === store.ERR_PAYMENT_CANCELLED)
+        store.trigger('refresh-cancelled');
+    else
+        store.trigger('refresh-failed');
 }
 
 function storekitDownloadActive(transactionIdentifier, productId, progress, timeRemaining) {

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -1924,10 +1924,12 @@ store.update = function() {};
 ///
 /// This method returns a promise-like object with the following functions:
 ///
+/// - `.cancelled(fn)` - Calls `fn` when the user cancelled the refresh request.
+/// - `.failed(fn)` - Calls `fn` when restoring purchases failed.
 /// - `.completed(fn)` - Calls `fn` when the queue of previous purchases have been processed.
 ///   At this point, all previously owned products should be in the approved state.
-/// - `.finished(fn)` - Calls `fn` when all purchased in the approved state have been finished
-///   or expired.
+/// - `.finished(fn)` - Calls `fn` when the restore is finished, i.e. it has failed, been cancelled,
+///   or all purchased in the approved state have been finished or expired.
 ///
 /// In the case of the restore purchases call, you will want to hide any progress bar when the
 /// `finished` callback is called.
@@ -1968,16 +1970,48 @@ var initialRefresh = true;
 function createPromise() {
     var events = {};
 
-    // refresh-completed is called when all owned products have been
-    // sent to the approved state.
-    store.once("", "refresh-completed", function() {
-        if (events["refresh-completed"]) return;
-        events["refresh-completed"] = true;
-        store.when().updated(checkFinished);
-        checkFinished(); // make sure this is called at least once
-    });
+    // User callbacks for each type of events
+    var callbacks = {
+        "refresh-failed": [],
+        "refresh-cancelled": [],
+        "refresh-completed": [],
+        "refresh-finished": [],
+    };
 
-    // trigger the refresh-finished event when no more products are in the
+    // Setup our own event handlers
+    store.once("", "refresh-failed", failed);
+    store.once("", "refresh-cancelled", cancelled);
+    store.once("", "refresh-completed", completed);
+    store.once("", "refresh-finished", finished);
+    store.error(error);
+
+    // Return the promise object
+    return {
+        cancelled: genPromise("refresh-cancelled"),
+        failed: genPromise("refresh-failed"),
+        completed: genPromise("refresh-completed"),
+        finished: genPromise("refresh-finished"),
+    };
+
+    // A promise function calls the callback or registers it
+    function genPromise(eventName) {
+        return function(cb) {
+            if (events[eventName])
+                cb();
+            else
+                callbacks[eventName].push(cb);
+            return this;
+        };
+    }
+
+    // Call all user callbacks for a given event
+    function callback(eventName) {
+        callbacks[eventName].forEach(function(cb) { cb(); });
+        callbacks[eventName] = [];
+    }
+
+    // Delete user callbacks for a given event
+    // Trigger the refresh-finished event when no more products are in the
     // approved state.
     function checkFinished() {
         if (events["refresh-finished"]) return;
@@ -1985,29 +2019,69 @@ function createPromise() {
         if (store.products.filter(isApproved).length === 0) {
             // done processing
             store.off(checkFinished);
-            events["refresh-finished"] = true;
-            setTimeout(function() {
-                // if "completed" triggers "finished",
-                // the setTimeout guarantees calling order
-                store.trigger("refresh-finished");
-            }, 100);
+            finish();
         }
     }
 
-    return {
-        completed: genPromise("refresh-completed"),
-        finished: genPromise("refresh-finished"),
-    };
-
-    function genPromise(eventName) {
-        return function(cb) {
-            if (events[eventName])
-                cb();
-            else
-                store.once("", eventName, cb);
-            return this;
-        };
+    // Remove base events handlers
+    function off() {
+        store.off(cancelled);
+        store.off(completed);
+        store.off(failed);
+        store.off(checkFinished);
+        store.off(error);
     }
+
+    // Fire a base event
+    function fire(eventName) {
+        if (events[eventName]) return false;
+        events[eventName] = true;
+        callback(eventName);
+        return true;
+    }
+
+    // Fire the refresh-finished event
+    function finish() {
+        off();
+        if (events["refresh-finished"]) return;
+        events["refresh-finished"] = true;
+        // setTimeout guarantees calling order
+        setTimeout(function() {
+            store.trigger("refresh-finished");
+        }, 100);
+    }
+
+    // refresh-cancelled called when the user cancelled the password popup
+    function cancelled() {
+        fire("refresh-cancelled");
+        finish();
+    }
+
+    // refresh-cancelled called when restore purchases couldn't complete
+    // (can't connect to store or user not allowed to make purchases)
+    function failed() {
+        fire("refresh-failed");
+        finish();
+    }
+
+    function error() {
+        fire("refresh-failed");
+        finish();
+    }
+
+    // refresh-completed is called when all owned products have been
+    // sent to the approved state.
+    function completed() {
+        if (fire("refresh-completed")) {
+            store.when().updated(checkFinished);
+            checkFinished(); // make sure this is called at least once
+        }
+    }
+
+    function finished() {
+        callback("refresh-finished");
+    }
+
 }
 
 store.refresh = function() {


### PR DESCRIPTION
Add `.failed()` and `.cancelled()` to the `refresh()` promise return value.

Ensuire `finished()` is called in all cases.