### PR TITLE
(ios) Disable appStoreReceipt refresh on purchase

### DIFF
--- a/src/js/platforms/ios-adapter.js
+++ b/src/js/platforms/ios-adapter.js
@@ -343,7 +343,7 @@ function storekitPurchasing(productId) {
         }
         if (product.state !== store.INITIATED)
             product.set("state", store.INITIATED);
-        storekit.refreshReceipts(); // We've asked for user password already anyway.
+        // storekit.refreshReceipts(); // We've asked for user password already anyway.
     });
 }
 


### PR DESCRIPTION
Refreshing the receipt might trigger a password prompt in some cases when the user initiates an order.

Some users did setup his device not to ask for a password when making a purchase, so this isn't good.

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#feature/no-refresh-on-purchase"
```
