### PR TITLE
Fix type chek error on tsc ^4.0.5

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -134,7 +134,7 @@ declare namespace IapStore {
     redeem(): void;
     off(callback: Function): void;
     order(id: string, additionalData?: null | IAdditionalData): void;
-    applicationUsername?: string | () => string;
+    applicationUsername?: string | (() => string);
   }
 
   export type TransactionType = 'ios-appstore' | 'android-playstore' | 'windows-store-transaction';


### PR DESCRIPTION
Without this have I can't use plugin with typescript, because of following error:

```
Function type notation must be parenthesized when used in a union type.  TS1385

    135 |     off(callback: Function): void;
    136 |     order(id: string, additionalData?: null | IAdditionalData): void;
  > 137 |     applicationUsername?: string | () => string;
                                             ^
    138 |   }
```