### PR TITLE
Add support for custom headers in store.validator

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -74,6 +74,11 @@ declare namespace IapStore {
     (product: IStoreProduct, callback: IValidatorCallback): void;
   }
 
+  export interface IValidatorTarget {
+    url: string;
+    headers?: { [token: string]: string };
+  }
+
   /** See https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#storeorderproduct-additionaldata for details */
   export type IAndroidProrationMode =
     'IMMEDIATE_WITH_TIME_PRORATION'
@@ -269,13 +274,14 @@ declare namespace IapStore {
      * Set this attribute to either:
      *   - the URL of your purchase validation service: Fovea's receipt validator (https://billing.fovea.cc) or your own service.
      *   - a custom validation callback method.
+     *   - an object contaning url and headers { url: 'https//...', headers: { Authorization: 'Bearer ' + authToken } }
      *
      * Note that a receipt validation server is required to properly handle subscriptions and refunds.
      *
      * See https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md#-storevalidator
      */
-    validator: string | IValidator;
-
+    validator: string | IValidator | IValidatorTarget;
+    
     /**
      * Set to true to automatically clean up the queue of transactions.
      *

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -85,6 +85,12 @@ store.utils = {
             if (xhr.readyState === 4)
                 store.utils.callExternal('ajax.done', doneCb);
         };
+        if (options.customHeaders) {
+            Object.keys(options.customHeaders).forEach(function (header) {
+                store.log.debug('ajax -> adding custom header: ' + header );
+                xhr.setRequestHeader( header, options.customHeaders[header]);
+            });
+        }
         xhr.setRequestHeader("Accept", "application/json");
         store.log.debug('ajax -> send request to ' + options.url);
         if (options.data) {

--- a/src/js/validator.js
+++ b/src/js/validator.js
@@ -114,7 +114,6 @@
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
-store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;

--- a/src/js/validator.js
+++ b/src/js/validator.js
@@ -114,6 +114,7 @@
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
+store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;
@@ -164,8 +165,9 @@ function runValidation() {
 
       // Post
       store.utils.ajax({
-          url: store.validator,
+          url: (typeof store.validator === 'string') ? store.validator : store.validator.url,
           method: 'POST',
+          customHeaders: (typeof store.validator === 'string') ? null : store.validator.headers,
           data: data,
           success: function(data) {
               store.log.debug("validator success, response: " + JSON.stringify(data));
@@ -313,7 +315,7 @@ store._validator = function(product, callback, isPrepared) {
         return;
     }
 
-    if (typeof store.validator === 'string') {
+    if (typeof store.validator === 'string' || typeof store.validator === 'object') {
         validationRequests.push({
             product: product,
             callback: callback

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -1606,6 +1606,7 @@ store.off = function(callback) {
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
+store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;
@@ -1656,8 +1657,9 @@ function runValidation() {
 
       // Post
       store.utils.ajax({
-          url: store.validator,
+          url: (typeof store.validator === 'string') ? store.validator : store.validator.url,
           method: 'POST',
+          customHeaders: (typeof store.validator === 'string') ? null : store.validator.headers,
           data: data,
           success: function(data) {
               store.log.debug("validator success, response: " + JSON.stringify(data));
@@ -1805,7 +1807,7 @@ store._validator = function(product, callback, isPrepared) {
         return;
     }
 
-    if (typeof store.validator === 'string') {
+    if (typeof store.validator === 'string' || typeof store.validator === 'object') {
         validationRequests.push({
             product: product,
             callback: callback
@@ -2829,6 +2831,12 @@ store.utils = {
             if (xhr.readyState === 4)
                 store.utils.callExternal('ajax.done', doneCb);
         };
+        if (options.customHeaders) {
+            Object.keys(options.customHeaders).forEach(function (header) {
+                store.log.debug('ajax -> adding custom header: ' + header );
+                xhr.setRequestHeader( header, options.customHeaders[header]);
+            });
+        }
         xhr.setRequestHeader("Accept", "application/json");
         store.log.debug('ajax -> send request to ' + options.url);
         if (options.data) {

--- a/www/store-android.js
+++ b/www/store-android.js
@@ -1606,7 +1606,6 @@ store.off = function(callback) {
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
-store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1627,7 +1627,6 @@ store.off = function(callback) {
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
-store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;

--- a/www/store-ios.js
+++ b/www/store-ios.js
@@ -1627,6 +1627,7 @@ store.off = function(callback) {
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
+store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;
@@ -1677,8 +1678,9 @@ function runValidation() {
 
       // Post
       store.utils.ajax({
-          url: store.validator,
+          url: (typeof store.validator === 'string') ? store.validator : store.validator.url,
           method: 'POST',
+          customHeaders: (typeof store.validator === 'string') ? null : store.validator.headers,
           data: data,
           success: function(data) {
               store.log.debug("validator success, response: " + JSON.stringify(data));
@@ -1826,7 +1828,7 @@ store._validator = function(product, callback, isPrepared) {
         return;
     }
 
-    if (typeof store.validator === 'string') {
+    if (typeof store.validator === 'string' || typeof store.validator === 'object') {
         validationRequests.push({
             product: product,
             callback: callback
@@ -2850,6 +2852,12 @@ store.utils = {
             if (xhr.readyState === 4)
                 store.utils.callExternal('ajax.done', doneCb);
         };
+        if (options.customHeaders) {
+            Object.keys(options.customHeaders).forEach(function (header) {
+                store.log.debug('ajax -> adding custom header: ' + header );
+                xhr.setRequestHeader( header, options.customHeaders[header]);
+            });
+        }
         xhr.setRequestHeader("Accept", "application/json");
         store.log.debug('ajax -> send request to ' + options.url);
         if (options.data) {

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -1606,6 +1606,7 @@ store.off = function(callback) {
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
+store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;
@@ -1656,8 +1657,9 @@ function runValidation() {
 
       // Post
       store.utils.ajax({
-          url: store.validator,
+          url: (typeof store.validator === 'string') ? store.validator : store.validator.url,
           method: 'POST',
+          customHeaders: (typeof store.validator === 'string') ? null : store.validator.headers,
           data: data,
           success: function(data) {
               store.log.debug("validator success, response: " + JSON.stringify(data));
@@ -1805,7 +1807,7 @@ store._validator = function(product, callback, isPrepared) {
         return;
     }
 
-    if (typeof store.validator === 'string') {
+    if (typeof store.validator === 'string' || typeof store.validator === 'object') {
         validationRequests.push({
             product: product,
             callback: callback
@@ -2829,6 +2831,12 @@ store.utils = {
             if (xhr.readyState === 4)
                 store.utils.callExternal('ajax.done', doneCb);
         };
+        if (options.customHeaders) {
+            Object.keys(options.customHeaders).forEach(function (header) {
+                store.log.debug('ajax -> adding custom header: ' + header );
+                xhr.setRequestHeader( header, options.customHeaders[header]);
+            });
+        }
         xhr.setRequestHeader("Accept", "application/json");
         store.log.debug('ajax -> send request to ' + options.url);
         if (options.data) {

--- a/www/store-windows.js
+++ b/www/store-windows.js
@@ -1606,7 +1606,6 @@ store.off = function(callback) {
 /// ** Validation error codes are [documented here](#validation-error-codes).
 ///
 store.validator = null;
-store.validatorCustomHeaders = null;
 
 var validationRequests = [];
 var timeout = null;


### PR DESCRIPTION
You indicated in #1082 that a PR for this might be welcome.

Changes proposed in this pull request:

-Add support for customHeaders in the validator url call.

I've done this by added a 3rd overload to the current string | function definition; which takes the form of an object with url and headers parameters.

`store.validator = { url: "https://...", headers: { authorization: "Bearer TOKEN" } }`

My specific use-case is I need the data server-side, so want to call fovea.cc validate rest API from the server-side.  I'm using firebase and want to authenticate against my validate url using the firebase bearer token.

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
