### PR TITLE
store.ready info transaction

### DIFF
--- a/www/store-android.js
+++ b/www/store-android.js
@@ -3772,7 +3772,7 @@ function getDeveloperPayload(product) {
                 store.log.debug("inappbilling.getPurchases() -> Success");
                 store.log.debug("                            -> " + typeof purchases);
                 store.log.debug("                            -> " + JSON.stringify(purchases));
-                // store.iabUpdatePurchases(purchases); (sent to the setPurchases listener)
+                store.iabUpdatePurchases(purchases); //(sent to the setPurchases listener)
                 store.ready(true);
                 if (callback) callback();
             },


### PR DESCRIPTION
In this case, upon receipt of the goods inside store.ready, information about the transaction and "state": "approved" will be immediately available.

Changes proposed in this pull request:

-
-

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
