### PR TITLE
reject validation of application products

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -183,7 +183,7 @@ store.Product.prototype.finish = function() {
     store.log.debug("product -> defer finishing " + this.id);
     defer(this, function() {
         store.log.debug("product -> finishing " + this.id);
-        if (this.state !== store.FINISHED && this.id) {
+        if (this.state !== store.FINISHED) {
             this.set('state', store.FINISHED);
             // The platform store should now handle the FINISHED event
             // and change the product status to VALID or OWNED.

--- a/src/js/product.js
+++ b/src/js/product.js
@@ -183,7 +183,7 @@ store.Product.prototype.finish = function() {
     store.log.debug("product -> defer finishing " + this.id);
     defer(this, function() {
         store.log.debug("product -> finishing " + this.id);
-        if (this.state !== store.FINISHED) {
+        if (this.state !== store.FINISHED && this.id) {
             this.set('state', store.FINISHED);
             // The platform store should now handle the FINISHED event
             // and change the product status to VALID or OWNED.
@@ -218,6 +218,10 @@ store.Product.prototype.verify = function() {
         // No need to verify a which status isn't approved
         // It means it already has been
         if (that.state !== store.APPROVED)
+            return;
+
+        // no need to verify an actual application
+        if (that.type === store.APPLICATION)
             return;
 
         store._validator(that, function(success, data) {


### PR DESCRIPTION
Changes proposed in this pull request:

- In the product fetching from iTunes, I'm seeing my application come back as a valid product which causes extra event trigger noise (for me)
-

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
