### PR TITLE
fix: Fixed a problem with onPurchasesUpdated that caused the list of purchases to become null and a nullpointer.

### DIFF
--- a/src/android/cc/fovea/PurchasePlugin.java
+++ b/src/android/cc/fovea/PurchasePlugin.java
@@ -531,7 +531,7 @@ public class PurchasePlugin
       final List<Purchase> purchases) {
     try {
       final int code = result.getResponseCode();
-      if (code == BillingResponseCode.OK) {
+      if (code == BillingResponseCode.OK && purchases != null && purchases.size() > 0)) {
         Log.d(mTag, "onPurchasesUpdated() -> Success");
         for (Purchase p : purchases) {
           mPurchases.add(0, p);


### PR DESCRIPTION
Fixed a problem with onPurchasesUpdated that caused the list of purchases to become null and a nullpointer.
We actually ran this plugin in production and were experiencing crashes due to Nullpointer as attached in crashlytics.
[crash.txt](https://github.com/j3k0/cordova-plugin-purchase/files/9949179/crash.txt)

Changes proposed in this pull request:

- Added check if purchases is not null when BillingResponseCode.OK is returned by onPurchasesUpdated.

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/masatada-kurihara/cordova-plugin-purchase.git#fix/onPurchasesUpdated-nullpointer"
```
