### PR TITLE
fix crash when logged out of icloud

### DIFF
--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -399,7 +399,7 @@ static NSString *toTimestamp(NSDate *date) {
     if ([quantity respondsToSelector:@selector(integerValue)]) {
         payment.quantity = [quantity integerValue];
     }
-    if (applicationUsername != nil && applicationUsername.length > 0) {
+    if (applicationUsername != nil && applicationUsername != NSNull.null && applicationUsername.length > 0) {
         DLog(@"purchase applicationUsername (%@).", applicationUsername);
         payment.applicationUsername = applicationUsername;
     }


### PR DESCRIPTION
tested on ios 16 / iphone8

Changes proposed in this pull request:

- fix crash when logged out of icloud

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
