### PR TITLE
Fix no appStoreReceipt on iOS App first launch

### DIFF
--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -331,8 +331,10 @@ namespace CdvPurchase {
             private async loadAppStoreReceipt(): Promise<undefined | ApplicationReceipt> {
                 let resolved = false;
                 return new Promise(resolve => {
-                    this.log.debug('using cached appstore receipt');
-                    if (this.bridge.appStoreReceipt) return resolve(this.bridge.appStoreReceipt);
+                    if (this.bridge.appStoreReceipt?.appStoreReceipt) {
+                        this.log.debug('using cached appstore receipt');
+                        return resolve(this.bridge.appStoreReceipt);
+                    }
                     this.log.debug('loading appstore receipt...');
                     this.bridge.loadReceipts(receipt => {
                         this.log.debug('appstore receipt loaded');

--- a/www/store.js
+++ b/www/store.js
@@ -2333,9 +2333,11 @@ var CdvPurchase;
             async loadAppStoreReceipt() {
                 let resolved = false;
                 return new Promise(resolve => {
-                    this.log.debug('using cached appstore receipt');
-                    if (this.bridge.appStoreReceipt)
+                    var _a;
+                    if ((_a = this.bridge.appStoreReceipt) === null || _a === void 0 ? void 0 : _a.appStoreReceipt) {
+                        this.log.debug('using cached appstore receipt');
                         return resolve(this.bridge.appStoreReceipt);
+                    }
                     this.log.debug('loading appstore receipt...');
                     this.bridge.loadReceipts(receipt => {
                         this.log.debug('appstore receipt loaded');


### PR DESCRIPTION
It's a tentative fix based on logs provided in the report (email), the issue hasn't occured here.

Here's the log:

```
[Debug] skin:iap LOG +26ms – "[CdvPurchase.AppleAppStore.Bridge] DEBUG: processing pending transactions" (main.a0051878.js, line 2)
[Debug] skin:iap [store] done +1ms (main.a0051878.js, line 2)
[Debug] skin:iap LOG +148ms – "[CdvPurchase.AppleAppStore] DEBUG: emitAppReceipt()" (main.a0051878.js, line 2)
[Debug] skin:iap LOG +0ms – "[CdvPurchase.AppleAppStore] DEBUG: using cached appstore receipt" (main.a0051878.js, line 2)
[Debug] skin:iap LOG +0ms – "[CdvPurchase.AppleAppStore] DEBUG: loading appstore receipt..." (main.a0051878.js, line 2)
[Debug] skin:iap LOG +0ms – "[CdvPurchase.AppleAppStore.Bridge] DEBUG: loading appStoreReceipt" (main.a0051878.js, line 2)
[Debug] skin:iap LOG +2ms – "[CdvPurchase.AppleAppStore.Bridge] DEBUG: infoPlist: com.xxxxxxxxxxxxx.xxxxxxxx,1.6.169,0,null" (main.a0051878.js, line 2)
[Debug] skin:iap LOG +0ms – "[CdvPurchase.AppleAppStore] DEBUG: appstore receipt loaded" (main.a0051878.js, line 2)
[Debug] skin:iap WARN +0ms – "[CdvPurchase.AppleAppStore] WARNING: no appStoreReceipt" (main.a0051878.js, line 2)
```

After loading we have this:

```
CdvPurchase.store.adapters.list[0].bridge.appStoreReceipt
 {
  "transactionsForProduct": {},
  "initialized": false,
  "registeredProducts": [
    "token__200",
    "test_iap",
    "membership__monthly",
    "test_sub"
  ],
  "needRestoreNotification": false,
  "pendingUpdates": [],
  "onPurchased": false,
  "onFailed": false,
  "onRestored": false,
  "options": {},
  "appStoreReceipt": {
    "appStoreReceipt": null,
    "bundleIdentifier": "com.xxxxxxxxxxxxx.xxxxxxxx",
    "bundleShortVersion": "1.6.169",
    "bundleNumericVersion": 0,
    "bundleSignature": null
  }
}
```

Notice how `bridge.appStoreReceipt` is not null but `bridge.appStoreReceipt.appStoreReceipt` is null, the proposed change should reload the receipt when this is the case.

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#patch-13.1.6"
```
