### PR TITLE
(Android) Fix: transactions do not finish after consuming a product

### DIFF
--- a/src/android/cc/fovea/PurchasePlugin.java
+++ b/src/android/cc/fovea/PurchasePlugin.java
@@ -1056,9 +1056,14 @@ public final class PurchasePlugin
         Log.d(mTag, "onConsumeResponse() -> Success");
         sendToListener("purchaseConsumed", new JSONObject()
             .put("purchase", toJSON(purchase)));
+        callSuccess();
+      } else {
+        Log.d(mTag, result.getDebugMessage());
+        callError(Constants.ERR_FINISH, result.getDebugMessage());
       }
     } catch (JSONException e) {
       Log.d(mTag, "onConsumeResponse() -> Failed: " + e.getMessage());
+      callError(Constants.ERR_UNKNOWN, e.getMessage());
     }
   }
 

--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -214,7 +214,11 @@ namespace CdvPurchase {
             finish(transaction: CdvPurchase.Transaction): Promise<IError | undefined> {
                 return new Promise(resolve => {
 
-                    const onSuccess = () => resolve(undefined);
+                    const onSuccess = () => {
+                        transaction.state = TransactionState.FINISHED;
+                        this.context.listener.receiptsUpdated(Platform.GOOGLE_PLAY, [transaction.parentReceipt]);
+                        resolve(undefined);
+                    };
                     const onFailure = (message: string, code?: ErrorCode) => resolve(storeError(code || ErrorCode.UNKNOWN, message));
 
                     const firstProduct = transaction.products[0];

--- a/www/store.js
+++ b/www/store.js
@@ -4154,7 +4154,11 @@ var CdvPurchase;
             /** @inheritDoc */
             finish(transaction) {
                 return new Promise(resolve => {
-                    const onSuccess = () => resolve(undefined);
+                    const onSuccess = () => {
+                        transaction.state = CdvPurchase.TransactionState.FINISHED;
+                        this.context.listener.receiptsUpdated(CdvPurchase.Platform.GOOGLE_PLAY, [transaction.parentReceipt]);
+                        resolve(undefined);
+                    };
                     const onFailure = (message, code) => resolve(CdvPurchase.storeError(code || CdvPurchase.ErrorCode.UNKNOWN, message));
                     const firstProduct = transaction.products[0];
                     if (!firstProduct)


### PR DESCRIPTION
Changes proposed in this pull request:

- This is a proposed fix for issue #1364 
- In PurchasePlugin.java `callSuccess()` and `callError()` were not called after a product is consumed. Though I was unsure what message to pass in callError, I opted to use [BillingResult.getDebugMessage()](https://developer.android.com/reference/com/android/billingclient/api/BillingResult#getDebugMessage())  but to be honest I have no idea what kind of message this returns.
- In googleplay-adapter.ts the transaction state was not set to `TransactionState.FINISHED`, following the same appstore-adapter.ts convention I figured that was needed.

