### PR TITLE
Add typescript 4.2.4 support

### DIFF
--- a/www/store.d.ts
+++ b/www/store.d.ts
@@ -316,13 +316,13 @@ declare namespace CdvPurchase {
             has(receipt: Receipt): boolean;
         }
         interface ValidatorController {
-            get validator(): string | Validator.Function | Validator.Target | undefined;
-            get localReceipts(): Receipt[];
-            get adapters(): Adapters;
-            get validator_privacy_policy(): PrivacyPolicyItem | PrivacyPolicyItem[] | undefined;
+            validator: string | Validator.Function | Validator.Target | undefined;
+            localReceipts: Receipt[];
+            adapters: Adapters;
+            validator_privacy_policy: PrivacyPolicyItem | PrivacyPolicyItem[] | undefined;
             getApplicationUsername(): string | undefined;
-            get verifiedCallbacks(): Callbacks<VerifiedReceipt>;
-            get unverifiedCallbacks(): Callbacks<UnverifiedReceipt>;
+            verifiedCallbacks: Callbacks<VerifiedReceipt>;
+            unverifiedCallbacks: Callbacks<UnverifiedReceipt>;
             finish(receipt: VerifiedReceipt): Promise<void>;
         }
         /** Handles communication with the remote receipt validation service */
@@ -920,15 +920,15 @@ declare namespace CdvPurchase {
         /**
          * List of products managed by the adapter.
          */
-        get products(): Product[];
+        products: Product[];
         /**
          * List of purchase receipts.
          */
-        get receipts(): Receipt[];
+        receipts: Receipt[];
         /**
          * Returns true is the adapter is supported on this device.
          */
-        get isSupported(): boolean;
+        isSupported: boolean;
         /**
          * Initializes a platform adapter.
          *
@@ -5155,7 +5155,7 @@ declare namespace CdvPurchase {
          */
         namespace Internal {
             interface PrivacyPolicyProvider {
-                get validator_privacy_policy(): undefined | string | string[];
+                validator_privacy_policy: undefined | string | string[];
             }
             function getDeviceInfo(store: PrivacyPolicyProvider): DeviceInfo;
         }


### PR DESCRIPTION
Changes proposed in this pull request:

- Angular version 12.2.6 which uses typescript 4.2.4 cannot understand syntax of version 4.7, now it can.