### PR TITLE
Improve typings for getPurchases

### DIFF
--- a/www/store.d.ts
+++ b/www/store.d.ts
@@ -4259,7 +4259,7 @@ declare namespace CdvPurchase {
                 init(success: () => void, fail: ErrorCallback, options: Options): void;
                 load(success: () => void, fail: ErrorCallback, skus: string[], inAppSkus: string[], subsSkus: string[]): void;
                 listener(msg: Message): void;
-                getPurchases(success: () => void, fail: ErrorCallback): void;
+                getPurchases(success:  (products: CdvPurchase.GooglePlay.Bridge.Purchase[]) => void, fail: ErrorCallback): void;
                 buy(success: () => void, fail: ErrorCallback, productId: string, additionalData: CdvPurchase.AdditionalData): void;
                 subscribe(success: () => void, fail: ErrorCallback, productId: string, additionalData: CdvPurchase.AdditionalData): void;
                 consumePurchase(success: () => void, fail: ErrorCallback, purchaseToken: string): void;


### PR DESCRIPTION
Changes proposed in this pull request:

- This adds typings for the success callback of getPurchases of Android bridge

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/platogo/cordova-plugin-purchase#google-getPurchases-typings"
```

Create the Android bridge and call the function: 
```
const androidBridge = new CdvPurchase.GooglePlay.Bridge.Bridge()

// call androidBridge.buy

androidBridge.getPurchases((products) => {
      console.log('getPurchases', products)
    }, () => console.log('error'))
```
