### PR TITLE
applicationUsername function should accept undefined as return value

### DIFF
--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -74,7 +74,7 @@ namespace CdvPurchase {
         public verbosity: LogLevel = LogLevel.ERROR;
 
         /** Return the identifier of the user for your application */
-        public applicationUsername?: string | (() => string);
+        public applicationUsername?: string | (() => string | undefined);
 
         /**
          * Get the application username as a string by either calling or returning {@link Store.applicationUsername}


### PR DESCRIPTION
I think the function to return the applicationUsername should also be able to return undefined (i.e. the default behavior should be applied), as it is also possible to set undefined directly.

Changes proposed in this pull request:

-
-

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
