### PR TITLE
Added commas because without them the example is highlighted as error

### DIFF
--- a/www/store.d.ts
+++ b/www/store.d.ts
@@ -204,8 +204,8 @@ declare namespace CdvPurchase {
          *
          * @example
          * Logger.console = {
-         *   log: (message) => { remoteLog('LOG', message); }
-         *   warn: (message) => { remoteLog('WARN', message); }
+         *   log: (message) => { remoteLog('LOG', message); },
+         *   warn: (message) => { remoteLog('WARN', message); },
          *   error: (message) => { remoteLog('ERROR', message); }
          * }
          */


### PR DESCRIPTION
I am a beginner myself but when I copied and pasted the code from the example, it was highlighted as error. 
It took me some time to understand that it was missing some commas. 
