### PR TITLE
feat: implements alternative billing

### DIFF
--- a/src/android/cc/fovea/PurchasePlugin.java
+++ b/src/android/cc/fovea/PurchasePlugin.java
@@ -24,6 +24,8 @@ import android.net.Uri;
 import android.util.Log;
 import com.android.billingclient.api.AcknowledgePurchaseParams;
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
+import com.android.billingclient.api.AlternativeBillingListener;
+import com.android.billingclient.api.AlternativeChoiceDetails;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClient.BillingResponseCode;
 import com.android.billingclient.api.BillingClient.FeatureType;
@@ -67,7 +69,8 @@ public final class PurchasePlugin
         extends CordovaPlugin
         implements PurchasesUpdatedListener,
         ConsumeResponseListener,
-        AcknowledgePurchaseResponseListener {
+        AcknowledgePurchaseResponseListener,
+        AlternativeBillingListener {
 
   /** Tag used for log messages. */
   private final String mTag = "CdvPurchase";
@@ -299,6 +302,7 @@ public final class PurchasePlugin
 
     mBillingClient = BillingClient
       .newBuilder(cordova.getActivity())
+      .enableAlternativeBilling(this)
       .enablePendingPurchases()
       .setListener(this)
       .build();
@@ -1293,5 +1297,10 @@ public final class PurchasePlugin
       ? result.getDebugMessage()
       : codeToMessage(code);
     return codeToString(code) + ": " + message;
+  }
+
+  @Override
+  public void userSelectedAlternativeBilling(@NonNull AlternativeChoiceDetails alternativeChoiceDetails) {
+    Log.d(mTag, "userSelectedAlternativeBilling() -> " + alternativeChoiceDetails.toString());
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Use alternative billing API

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
