### PR TITLE
fix(docs): update namespace usage recommendations to avoid minificati…

### DIFF
--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -21,10 +21,23 @@
  *
  * When you see, for example `ProductType.PAID_SUBSCRIPTION`, it refers to `CdvPurchase.ProductType.PAID_SUBSCRIPTION`.
  *
- * In the files that interact with the plugin, I recommend creating those shortcuts (and more if needed):
+ * In your code, you should access members directly through the CdvPurchase namespace:
  *
  * ```ts
- * const {store, ProductType, Platform, LogLevel} = CdvPurchase;
+ * // Recommended approach (works reliably with minification)
+ * CdvPurchase.store.initialize();
+ * CdvPurchase.store.register({
+ *   id: 'my-product',
+ *   type: CdvPurchase.ProductType.PAID_SUBSCRIPTION,
+ *   platform: CdvPurchase.Platform.APPLE_APPSTORE
+ * });
+ * ```
+ * 
+ * Note: Using destructuring with the namespace may cause issues with minification tools:
+ * 
+ * ```ts
+ * // NOT recommended - may cause issues with minification tools like Terser
+ * const { store, ProductType, Platform, LogLevel } = CdvPurchase;
  * ```
  */
 namespace CdvPurchase {


### PR DESCRIPTION
# Fix for Issue #1621: Recommended Namespace Shortcuts With Minify Can Cause Error

## Description
This PR addresses issue #1621 where recommended namespace shortcuts in the documentation can cause errors when using minification tools like Terser.

The problem occurs when users follow the existing recommendation to use object destructuring:
```typescript
const { store, ProductType, Platform, LogLevel } = CdvPurchase;
```

When this code is processed by minification tools, they may rename the destructured variables, which can lead to errors in the minified build:
```typescript
const { store: EY, ProductType: _Y, Platform: vY, LogLevel: TY } = CdvPurchase;
```

## Changes
- Updated the documentation in `src/ts/store.ts` to recommend accessing properties directly through the CdvPurchase namespace instead of using destructuring
- Added a note explaining why destructuring should be avoided when using minification tools
- Provided a clear code example of the recommended approach

## Testing
No functionality has been changed, only documentation. The updated recommendation will help prevent minification errors.

## Related Issues
- Fixes #1621
- Related to #1419 (Feature request to remove namespaces)
