### PR TITLE
Add support for multi-quantity purchases on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Cordova-Plugin-Purchase plugin is designed to be easy to use and integrate i
 |  | AppStore (iOS / macOS) | Google Play | Braintree (iOS / Android) |
 |--|--|--|--|
 | consumables | ✅ | ✅ | ✅ |
+| multi-quantity consumables |  | ✅ |  |
 | non consumables | ✅ | ✅ |  |
 | subscriptions | ✅ | ✅ |  |
 | restore purchases | ✅ | ✅ | ✅ |

--- a/doc/multi-quantity-purchases.md
+++ b/doc/multi-quantity-purchases.md
@@ -1,0 +1,90 @@
+# Multi-Quantity Purchases
+
+Starting with version 13.11.1, cordova-plugin-purchase provides support for multi-quantity consumable purchases on Android (Google Play).
+
+## Overview
+
+The Google Play Billing Library allows users to purchase multiple quantities of a consumable product in a single transaction. This feature is useful for apps that sell virtual goods or currencies that users might want to buy in bulk.
+
+For example, a user might want to purchase 5 coins or 10 gems at once, instead of making separate transactions for each item.
+
+## How It Works
+
+When a purchase is completed, the plugin will now expose the `quantity` field from Google Play in the transaction object. This allows your app to know how many items were purchased in a single transaction.
+
+## Usage
+
+### Checking Quantity in Transactions
+
+When processing a transaction, you can check the `quantity` field to determine how many items were purchased:
+
+```javascript
+store.when()
+  .approved(transaction => {
+    // Get the quantity from the transaction
+    const quantity = transaction.quantity || 1;
+
+    // Process the transaction based on quantity
+    console.log(`User purchased ${quantity} items`);
+
+    // You can credit the user's account accordingly
+    creditUserAccount(transaction.products[0].id, quantity);
+
+    // Finish the transaction
+    transaction.finish();
+  });
+```
+
+### Important Notes
+
+1. **Platform Support**: Multi-quantity purchases are only supported on Android (Google Play). On other platforms like iOS, the quantity value will always be 1.
+
+2. **Product Types**: Multi-quantity purchases only apply to consumable products. For non-consumable products and subscriptions, the quantity will always be 1.
+
+3. **Default Value**: Always provide a fallback (e.g., `quantity || 1`) when using this field, as it might not be available on all platforms or in older plugin versions.
+
+4. **Consumption**: When a multi-quantity purchase is consumed, all quantities are consumed at once. The Google Play Billing Library doesn't support partial consumption of multi-quantity purchases.
+
+## Example Implementation
+
+Here's a complete example of handling multi-quantity purchases:
+
+```javascript
+// Set up the store
+document.addEventListener('deviceready', function() {
+  // Register your consumable product
+  store.register({
+    id: 'my_consumable',
+    type: store.CONSUMABLE
+  });
+
+  // Set up the purchase flow
+  store.when('my_consumable')
+    .approved(transaction => {
+      // Get the quantity (default to 1 if not specified)
+      const quantity = transaction.quantity || 1;
+
+      // Credit the user's account with the appropriate quantity
+      addItemsToUserInventory('my_consumable', quantity);
+
+      // Finish the transaction
+      transaction.finish();
+    });
+
+  // Initialize the store
+  store.refresh();
+}, false);
+
+// Function to add items to user inventory
+function addItemsToUserInventory(productId, quantity) {
+  console.log(`Adding ${quantity} of ${productId} to user inventory`);
+  // Your implementation here
+}
+```
+
+## Notes for Receipt Validation Services
+
+If you're using a receipt validation service, make sure it properly handles the quantity field when validating receipts. The validation service should interpret the quantity value and apply the appropriate business logic when crediting the user's account.
+
+Call `transaction.verify()` and only credit the user when the transaction has been verified.
+

--- a/src/android/cc/fovea/PurchasePlugin.java
+++ b/src/android/cc/fovea/PurchasePlugin.java
@@ -367,7 +367,8 @@ public final class PurchasePlugin
       .put("accountId", p.getAccountIdentifiers().getObfuscatedAccountId())
       .put("profileId", p.getAccountIdentifiers().getObfuscatedProfileId())
       .put("signature", p.getSignature())
-      .put("receipt", p.getOriginalJson().toString());
+      .put("receipt", p.getOriginalJson().toString())
+      .put("quantity", p.getQuantity());
   }
 
   BillingResult mInAppResult;

--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -48,6 +48,7 @@ namespace CdvPurchase {
                 if (typeof purchase.acknowledged !== 'undefined') this.isAcknowledged = purchase.acknowledged;
                 if (typeof purchase.consumed !== 'undefined') this.isConsumed = purchase.consumed;
                 if (typeof purchase.autoRenewing !== 'undefined') this.renewalIntent = purchase.autoRenewing ? RenewalIntent.RENEW : RenewalIntent.LAPSE;
+                if (typeof purchase.quantity !== 'undefined') this.quantity = purchase.quantity;
                 
                 // Handle expiryTimeMillis for subscriptions
                 if (purchase.expiryTimeMillis) {

--- a/src/ts/platforms/google-play/googleplay-bridge.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge.ts
@@ -130,7 +130,14 @@ namespace CdvPurchase {
                 /** Token that uniquely identifies a purchase for a given item and user pair. */
                 purchaseToken: string;
 
-                /** quantity of the purchased product */
+                /** Quantity of items purchased in a single transaction.
+                 * 
+                 * For consumable products, this value represents the number of items purchased.
+                 * For non-consumable products and subscriptions, this value is always 1.
+                 * 
+                 * This is particularly useful for apps that support multi-quantity purchases
+                 * through Google Play Billing Library.
+                 */
                 quantity: number;
 
                 /** Whether the purchase has been acknowledged. */

--- a/src/ts/transaction.ts
+++ b/src/ts/transaction.ts
@@ -69,6 +69,17 @@ namespace CdvPurchase
         /** Currency used to pay for the transaction, if known. */
         currency?: string;
 
+        /**
+         * Quantity of items purchased in a single transaction.
+         * 
+         * For consumable products, this value represents the number of items purchased.
+         * For non-consumable products and subscriptions, this value is always 1.
+         * 
+         * This is only supported on Android (Google Play) platform when using the multi-quantity purchase feature.
+         * On other platforms, the quantity is always 1.
+         */
+        quantity?: number;
+
         /** Purchased products */
         products: {
 


### PR DESCRIPTION
## Add support for multi-quantity purchases on Android

This PR implements support for multi-quantity consumable purchases on the Google Play platform. This feature allows users to buy multiple quantities of the same consumable product in a single transaction, addressing issue #1629.

### Changes:

1. Updated the Android native code to properly expose the quantity field from Google Play purchase objects
2. Added documentation for the quantity field in the Transaction interface and GooglePlay Bridge Purchase interface
3. Improved the TypeScript transaction class to include the quantity field
4. Added comprehensive documentation on how to use the multi-quantity purchases feature
5. Updated README.md to include multi-quantity purchases in the features table

Fixes #1629
