### PR TITLE
Fix redundant finish operations for transactions processed by validator

### DIFF
--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -112,6 +112,8 @@ namespace CdvPurchase {
 
             supportsParallelLoading = false;
 
+            canSkipFinish = true;
+
             /** List of products managed by the GooglePlay adapter */
             get products(): GProduct[] { return this._products.products; }
             private _products: Products;

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -690,12 +690,7 @@ namespace CdvPurchase {
                     // Find matching purchase in the verified collection
                     const verifiedPurchase = receipt.collection.find(p => {
                         // Match by transactionId if available
-                        if (p.transactionId && p.transactionId === transaction.transactionId) 
-                            return true;
-                        
-                        // Otherwise match by product id and purchase id if available
-                        return p.id === transaction.products[0]?.id && 
-                               p.purchaseId === transaction.purchaseId;
+                        return (p.transactionId && p.transactionId === transaction.transactionId);
                     });
                     
                     if (verifiedPurchase) {
@@ -712,32 +707,15 @@ namespace CdvPurchase {
                             transaction.isConsumed = true;
                             skipNativeFinish = true;
                         }
-                        
-                        // If the verified purchase has no explicit acknowledgement or consumption status,
-                        // we can make some assumptions based on other properties
-                        
-                        // For subscription transaction - a server-validated subscription is implicitly acknowledged
-                        const productId = transaction.products[0]?.id;
-                        const product = productId ? this.get(productId, transaction.platform) : undefined;
-                        if (product && 
-                            verifiedPurchase.isAcknowledged !== false && // Only if not explicitly marked as not acknowledged
-                            (product.type === ProductType.PAID_SUBSCRIPTION || 
-                             product.type === ProductType.FREE_SUBSCRIPTION ||
-                             product.type === ProductType.NON_RENEWING_SUBSCRIPTION)) {
-                            // If we have the purchase info in verified purchases, it's definitely acknowledged
-                            this.log.info(`Subscription transaction ${transaction.transactionId} implicitly acknowledged`);
-                            transaction.isAcknowledged = true;
-                            skipNativeFinish = true;
-                        }
                     }
                 }
-                
-                if (skipNativeFinish && transaction.state === TransactionState.APPROVED) {
+
+                const adapter = this.adapters.findReady(transaction.platform);
+
+                if (adapter?.canSkipFinish && skipNativeFinish && transaction.state === TransactionState.APPROVED) {
                     transaction.state = TransactionState.FINISHED;
                 }
                 else {
-                    // Only call the native adapter if we haven't determined that the transaction
-                    // is already consumed or acknowledged
                     const adapter = this.adapters.findReady(transaction.platform)?.finish(transaction);
                 }
             });

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -130,6 +130,14 @@ namespace CdvPurchase {
         isSupported: boolean;
 
         /**
+         * Returns true if the adapter can skip the native finish method for a transaction.
+         * 
+         * Some platforms (e.g. Apple AppStore) require explicit acknowledgement of a purchase so it can be removed from
+         * the queue of pending transactions, regardless of whether the transaction is acknowledged or consumed already.
+         */
+        canSkipFinish?: boolean;
+
+        /**
          * Initializes a platform adapter.
          *
          * Will resolve when initialization is complete.

--- a/src/ts/validator/verified-receipt.ts
+++ b/src/ts/validator/verified-receipt.ts
@@ -120,6 +120,12 @@ namespace CdvPurchase {
         /** True when a subscription is expired. */
         isExpired?: boolean;
 
+        /** True when a purchase has been acknowledged to the platform. */
+        isAcknowledged?: boolean;
+
+        /** True when a purchase has been consumed (for consumable products). */
+        isConsumed?: boolean;
+
         /** Renewal intent. */
         renewalIntent?: string;
 


### PR DESCRIPTION
## Description

This PR addresses issue #1638 by improving how the plugin handles transactions that have already been acknowledged or consumed by a custom receipt validation server. The changes help prevent redundant finish operations that could cause errors when a backend has already processed purchases.

## Changes

1. Added `isAcknowledged` and `isConsumed` properties to the `VerifiedPurchase` interface
2. Enhanced the `Store.finish()` method to check if transactions have already been processed according to receipt validation
3. Added platform-specific control via `canSkipFinish` flag to ensure safe operation across different platforms
4. Set `canSkipFinish = true` for Google Play, which allows skipping redundant finish operations
5. Updated transaction state handling to mark skipped transactions as FINISHED

## How It Works

When a receipt validation service reports that a transaction has been acknowledged or consumed, the plugin will now:

1. Recognize this status from the verification response
2. Skip the native platform finish operation for platforms that support this behavior
3. Properly update the transaction state to maintain consistency

This approach respects platform differences - for example, Apple AppStore requires finishing transactions regardless of status to remove them from the queue, while Google Play can safely skip finish operations for already processed transactions.

## Related Issues

Fixes #1638
