### PR TITLE
feat: StoreKit 2 support via extension plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ For a more complete example with a backend integration, check:
 
 ### Extensions
 
+ - [StoreKit 2](https://github.com/j3k0/cordova-plugin-purchase-storekit2)
+   - Enable StoreKit 2 on iOS 15+. When installed, the Apple AppStore adapter automatically upgrades from StoreKit 1 to StoreKit 2 — no code changes needed.
+   - Requires cordova-ios 7+ (tested with cordova-ios 8).
+   - `cordova plugin add cordova-plugin-purchase-storekit2`
  - [Braintree SDK](https://github.com/j3k0/cordova-plugin-purchase-braintree)
    - Add the Braintree SDK to your application, enable Braintree on iOS and Android.
 

--- a/api/classes/CdvPurchase.AppleAppStore.Adapter.md
+++ b/api/classes/CdvPurchase.AppleAppStore.Adapter.md
@@ -33,6 +33,7 @@ Adapter for Apple AppStore using StoreKit version 1
 - [ready](CdvPurchase.AppleAppStore.Adapter.md#ready)
 - [receiptsUpdated](CdvPurchase.AppleAppStore.Adapter.md#receiptsupdated)
 - [supportsParallelLoading](CdvPurchase.AppleAppStore.Adapter.md#supportsparallelloading)
+- [useSK2](CdvPurchase.AppleAppStore.Adapter.md#usesk2)
 
 ### Accessors
 
@@ -110,7 +111,7 @@ ___
 
 ### bridge
 
-• **bridge**: [`Bridge`](CdvPurchase.AppleAppStore.Bridge.Bridge.md)
+• **bridge**: [`BridgeInterface`](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md)
 
 ___
 
@@ -237,6 +238,14 @@ Set to true if receipts and products can be loaded in parallel
 #### Implementation of
 
 [Adapter](../interfaces/CdvPurchase.Adapter.md).[supportsParallelLoading](../interfaces/CdvPurchase.Adapter.md#supportsparallelloading)
+
+___
+
+### useSK2
+
+• `Readonly` **useSK2**: `boolean`
+
+True when the StoreKit 2 extension is active
 
 ## Accessors
 

--- a/api/classes/CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md
+++ b/api/classes/CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md
@@ -1,6 +1,6 @@
-# Class: Bridge
+# Class: SK2NativeBridge
 
-[AppleAppStore](../modules/CdvPurchase.AppleAppStore.md).[Bridge](../modules/CdvPurchase.AppleAppStore.Bridge.md).Bridge
+[AppleAppStore](../modules/CdvPurchase.AppleAppStore.md).[SK2Bridge](../modules/CdvPurchase.AppleAppStore.SK2Bridge.md).SK2NativeBridge
 
 Shared interface implemented by both the SK1 and SK2 bridges.
 The adapter programs against this interface, not a concrete class.
@@ -13,47 +13,46 @@ The adapter programs against this interface, not a concrete class.
 
 ### Constructors
 
-- [constructor](CdvPurchase.AppleAppStore.Bridge.Bridge.md#constructor)
+- [constructor](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#constructor)
 
 ### Properties
 
-- [appStoreReceipt](CdvPurchase.AppleAppStore.Bridge.Bridge.md#appstorereceipt)
-- [onFailed](CdvPurchase.AppleAppStore.Bridge.Bridge.md#onfailed)
-- [onPurchased](CdvPurchase.AppleAppStore.Bridge.Bridge.md#onpurchased)
-- [onRestored](CdvPurchase.AppleAppStore.Bridge.Bridge.md#onrestored)
-- [options](CdvPurchase.AppleAppStore.Bridge.Bridge.md#options)
-- [transactionsForProduct](CdvPurchase.AppleAppStore.Bridge.Bridge.md#transactionsforproduct)
+- [appStoreReceipt](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#appstorereceipt)
+- [isSK2](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#issk2)
+- [options](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#options)
+- [transactionsForProduct](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#transactionsforproduct)
 
 ### Methods
 
-- [canMakePayments](CdvPurchase.AppleAppStore.Bridge.Bridge.md#canmakepayments)
-- [finalizeTransactionUpdates](CdvPurchase.AppleAppStore.Bridge.Bridge.md#finalizetransactionupdates)
-- [finish](CdvPurchase.AppleAppStore.Bridge.Bridge.md#finish)
-- [init](CdvPurchase.AppleAppStore.Bridge.Bridge.md#init)
-- [lastTransactionUpdated](CdvPurchase.AppleAppStore.Bridge.Bridge.md#lasttransactionupdated)
-- [load](CdvPurchase.AppleAppStore.Bridge.Bridge.md#load)
-- [loadReceipts](CdvPurchase.AppleAppStore.Bridge.Bridge.md#loadreceipts)
-- [manageBilling](CdvPurchase.AppleAppStore.Bridge.Bridge.md#managebilling)
-- [manageSubscriptions](CdvPurchase.AppleAppStore.Bridge.Bridge.md#managesubscriptions)
-- [parseReceiptArgs](CdvPurchase.AppleAppStore.Bridge.Bridge.md#parsereceiptargs)
-- [presentCodeRedemptionSheet](CdvPurchase.AppleAppStore.Bridge.Bridge.md#presentcoderedemptionsheet)
-- [processPendingTransactions](CdvPurchase.AppleAppStore.Bridge.Bridge.md#processpendingtransactions)
-- [purchase](CdvPurchase.AppleAppStore.Bridge.Bridge.md#purchase)
-- [refreshReceipts](CdvPurchase.AppleAppStore.Bridge.Bridge.md#refreshreceipts)
-- [restore](CdvPurchase.AppleAppStore.Bridge.Bridge.md#restore)
-- [restoreCompletedTransactionsFailed](CdvPurchase.AppleAppStore.Bridge.Bridge.md#restorecompletedtransactionsfailed)
-- [restoreCompletedTransactionsFinished](CdvPurchase.AppleAppStore.Bridge.Bridge.md#restorecompletedtransactionsfinished)
-- [transactionUpdated](CdvPurchase.AppleAppStore.Bridge.Bridge.md#transactionupdated)
+- [canMakePayments](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#canmakepayments)
+- [finalizeTransactionUpdates](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#finalizetransactionupdates)
+- [finish](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#finish)
+- [init](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#init)
+- [lastTransactionUpdated](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#lasttransactionupdated)
+- [load](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#load)
+- [loadReceipts](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#loadreceipts)
+- [manageBilling](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#managebilling)
+- [manageSubscriptions](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#managesubscriptions)
+- [parseReceiptArgs](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#parsereceiptargs)
+- [presentCodeRedemptionSheet](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#presentcoderedemptionsheet)
+- [processPendingTransactions](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#processpendingtransactions)
+- [purchase](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#purchase)
+- [refreshReceipts](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#refreshreceipts)
+- [restore](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#restore)
+- [restoreCompletedTransactionsFailed](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#restorecompletedtransactionsfailed)
+- [restoreCompletedTransactionsFinished](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#restorecompletedtransactionsfinished)
+- [transactionUpdated](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#transactionupdated)
+- [isAvailable](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md#isavailable)
 
 ## Constructors
 
 ### constructor
 
-• **new Bridge**(): [`Bridge`](CdvPurchase.AppleAppStore.Bridge.Bridge.md)
+• **new SK2NativeBridge**(): [`SK2NativeBridge`](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md)
 
 #### Returns
 
-[`Bridge`](CdvPurchase.AppleAppStore.Bridge.Bridge.md)
+[`SK2NativeBridge`](CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md)
 
 ## Properties
 
@@ -61,7 +60,7 @@ The adapter programs against this interface, not a concrete class.
 
 • `Optional` **appStoreReceipt**: ``null`` \| [`ApplicationReceipt`](../interfaces/CdvPurchase.AppleAppStore.ApplicationReceipt.md)
 
-The application receipt from AppStore, cached in javascript
+Cached app store receipt
 
 #### Implementation of
 
@@ -69,35 +68,21 @@ The application receipt from AppStore, cached in javascript
 
 ___
 
-### onFailed
+### isSK2
 
-• **onFailed**: `boolean` = `false`
+• `Readonly` **isSK2**: ``true``
 
-**`Deprecated`**
+True when this bridge is active (SK2 extension installed + iOS 15+)
 
-___
+#### Implementation of
 
-### onPurchased
-
-• **onPurchased**: `boolean` = `false`
-
-**`Deprecated`**
-
-___
-
-### onRestored
-
-• **onRestored**: `boolean` = `false`
-
-**`Deprecated`**
+[BridgeInterface](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md).[isSK2](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#issk2)
 
 ___
 
 ### options
 
-• **options**: [`BridgeCallbacks`](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md)
-
-Callbacks set by the adapter
+• **options**: [`SK2BridgeCallbacks`](../interfaces/CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md)
 
 ___
 
@@ -105,7 +90,7 @@ ___
 
 • **transactionsForProduct**: `Object` = `{}`
 
-Transactions for a given product
+Transaction IDs grouped by product
 
 #### Index signature
 
@@ -120,8 +105,6 @@ Transactions for a given product
 ### canMakePayments
 
 ▸ **canMakePayments**(`success`, `error`): `void`
-
-Checks if device/user is allowed to make in-app purchases
 
 #### Parameters
 
@@ -176,17 +159,13 @@ ___
 
 ▸ **init**(`options`, `success`, `error`): `void`
 
-Initialize the AppStore bridge.
-
-This calls the native "setup" method from the "InAppPurchase" Objective-C class.
-
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `options` | `Partial`\<[`BridgeOptions`](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeOptions.md)\> | Options for the bridge |
-| `success` | () => `void` | Called when the bridge is ready |
-| `error` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` | Called when the bridge failed to initialize |
+| Name | Type |
+| :------ | :------ |
+| `options` | `Partial`\<[`BridgeOptions`](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeOptions.md)\> |
+| `success` | () => `void` |
+| `error` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` |
 
 #### Returns
 
@@ -212,16 +191,13 @@ ___
 
 ▸ **load**(`productIds`, `success`, `error`): `void`
 
-Retrieves localized product data, including price (as localized
-string), name, description of multiple products.
-
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `productIds` | `string`[] | An array of product identifier strings. |
-| `success` | (`validProducts`: [`ValidProduct`](../interfaces/CdvPurchase.AppleAppStore.Bridge.ValidProduct.md)[], `invalidProductIds`: `string`[]) => `void` | - |
-| `error` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` | - |
+| Name | Type |
+| :------ | :------ |
+| `productIds` | `string`[] |
+| `success` | (`validProducts`: [`ValidProduct`](../interfaces/CdvPurchase.AppleAppStore.Bridge.ValidProduct.md)[], `invalidProductIds`: `string`[]) => `void` |
+| `error` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` |
 
 #### Returns
 
@@ -302,7 +278,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `args` | `RawReceiptArgs` |
+| `args` | [`string`, `string`, `string`, `number`, `string`] |
 
 #### Returns
 
@@ -344,18 +320,16 @@ ___
 
 ▸ **purchase**(`productId`, `quantity`, `applicationUsername`, `discount`, `success`, `error`): `void`
 
-Makes an in-app purchase.
-
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `productId` | `string` | The product identifier. e.g. "com.example.MyApp.myproduct" |
-| `quantity` | `number` | Quantity of product to purchase |
-| `applicationUsername` | `undefined` \| `string` | - |
-| `discount` | `undefined` \| [`PaymentDiscount`](../interfaces/CdvPurchase.AppleAppStore.PaymentDiscount.md) | - |
-| `success` | () => `void` | - |
-| `error` | () => `void` | - |
+| Name | Type |
+| :------ | :------ |
+| `productId` | `string` |
+| `quantity` | `number` |
+| `applicationUsername` | `undefined` \| `string` |
+| `discount` | `undefined` \| [`PaymentDiscount`](../interfaces/CdvPurchase.AppleAppStore.PaymentDiscount.md) |
+| `success` | () => `void` |
+| `error` | () => `void` |
 
 #### Returns
 
@@ -391,10 +365,6 @@ ___
 ### restore
 
 ▸ **restore**(`callback?`): `void`
-
-Asks the payment queue to restore previously completed purchases.
-
-The restored transactions are passed to the onRestored callback, so make sure you define a handler for that first.
 
 #### Parameters
 
@@ -440,7 +410,9 @@ ___
 
 ### transactionUpdated
 
-▸ **transactionUpdated**(`state`, `errorCode`, `errorText`, `transactionIdentifier`, `productId`, `transactionReceipt`, `originalTransactionIdentifier`, `transactionDate`, `discountId`): `void`
+▸ **transactionUpdated**(`state`, `errorCode`, `errorText`, `transactionIdentifier`, `productId`, `transactionReceipt`, `originalTransactionIdentifier`, `transactionDate`, `discountId`, `expirationDate?`, `jwsRepresentation?`): `void`
+
+Called from native. Same as SK1 but with extra SK2 fields.
 
 #### Parameters
 
@@ -455,7 +427,21 @@ ___
 | `originalTransactionIdentifier` | `undefined` \| `string` |
 | `transactionDate` | `undefined` \| `string` |
 | `discountId` | `undefined` \| `string` |
+| `expirationDate?` | `string` |
+| `jwsRepresentation?` | `string` |
 
 #### Returns
 
 `void`
+
+___
+
+### isAvailable
+
+▸ **isAvailable**(): `boolean`
+
+Check if the SK2 extension plugin is installed
+
+#### Returns
+
+`boolean`

--- a/api/classes/CdvPurchase.AppleAppStore.SKTransaction.md
+++ b/api/classes/CdvPurchase.AppleAppStore.SKTransaction.md
@@ -20,6 +20,7 @@ StoreKit transaction
 - [isAcknowledged](CdvPurchase.AppleAppStore.SKTransaction.md#isacknowledged)
 - [isConsumed](CdvPurchase.AppleAppStore.SKTransaction.md#isconsumed)
 - [isPending](CdvPurchase.AppleAppStore.SKTransaction.md#ispending)
+- [jwsRepresentation](CdvPurchase.AppleAppStore.SKTransaction.md#jwsrepresentation)
 - [lastRenewalDate](CdvPurchase.AppleAppStore.SKTransaction.md#lastrenewaldate)
 - [originalTransactionId](CdvPurchase.AppleAppStore.SKTransaction.md#originaltransactionid)
 - [platform](CdvPurchase.AppleAppStore.SKTransaction.md#platform)
@@ -113,6 +114,14 @@ True when the transaction is still pending payment.
 #### Inherited from
 
 [Transaction](CdvPurchase.Transaction.md).[isPending](CdvPurchase.Transaction.md#ispending)
+
+___
+
+### jwsRepresentation
+
+• `Optional` **jwsRepresentation**: `string`
+
+JWS representation of the transaction (StoreKit 2 only)
 
 ___
 
@@ -297,7 +306,7 @@ ___
 
 ### refresh
 
-▸ **refresh**(`productId?`, `originalTransactionIdentifier?`, `transactionDate?`, `discountId?`): `void`
+▸ **refresh**(`productId?`, `originalTransactionIdentifier?`, `transactionDate?`, `discountId?`, `expirationDateMs?`, `jwsRepresentation?`): `void`
 
 #### Parameters
 
@@ -307,6 +316,8 @@ ___
 | `originalTransactionIdentifier?` | `string` |
 | `transactionDate?` | `string` |
 | `discountId?` | `string` |
+| `expirationDateMs?` | `string` |
+| `jwsRepresentation?` | `string` |
 
 #### Returns
 

--- a/api/interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md
+++ b/api/interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md
@@ -8,6 +8,8 @@
 
   ↳ [`BridgeOptions`](CdvPurchase.AppleAppStore.Bridge.BridgeOptions.md)
 
+  ↳ [`SK2BridgeCallbacks`](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md)
+
 ## Table of contents
 
 ### Properties

--- a/api/interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md
+++ b/api/interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md
@@ -1,0 +1,251 @@
+# Interface: BridgeInterface
+
+[AppleAppStore](../modules/CdvPurchase.AppleAppStore.md).[Bridge](../modules/CdvPurchase.AppleAppStore.Bridge.md).BridgeInterface
+
+Shared interface implemented by both the SK1 and SK2 bridges.
+The adapter programs against this interface, not a concrete class.
+
+## Implemented by
+
+- [`Bridge`](../classes/CdvPurchase.AppleAppStore.Bridge.Bridge.md)
+- [`SK2NativeBridge`](../classes/CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md)
+
+## Table of contents
+
+### Properties
+
+- [appStoreReceipt](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#appstorereceipt)
+- [isSK2](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#issk2)
+- [transactionsForProduct](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#transactionsforproduct)
+
+### Methods
+
+- [canMakePayments](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#canmakepayments)
+- [finish](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#finish)
+- [init](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#init)
+- [load](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#load)
+- [loadReceipts](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#loadreceipts)
+- [manageBilling](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#managebilling)
+- [manageSubscriptions](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#managesubscriptions)
+- [presentCodeRedemptionSheet](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#presentcoderedemptionsheet)
+- [purchase](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#purchase)
+- [refreshReceipts](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#refreshreceipts)
+- [restore](CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md#restore)
+
+## Properties
+
+### appStoreReceipt
+
+• `Optional` **appStoreReceipt**: ``null`` \| [`ApplicationReceipt`](CdvPurchase.AppleAppStore.ApplicationReceipt.md)
+
+Cached app store receipt
+
+___
+
+### isSK2
+
+• `Optional` `Readonly` **isSK2**: `boolean`
+
+Whether this bridge uses StoreKit 2
+
+___
+
+### transactionsForProduct
+
+• **transactionsForProduct**: `Object`
+
+Transaction IDs grouped by product
+
+#### Index signature
+
+▪ [productId: `string`]: `string`[]
+
+## Methods
+
+### canMakePayments
+
+▸ **canMakePayments**(`success`, `error`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `success` | () => `void` |
+| `error` | (`message`: `string`) => `void` |
+
+#### Returns
+
+`void`
+
+___
+
+### finish
+
+▸ **finish**(`transactionId`, `success`, `error`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transactionId` | `string` |
+| `success` | () => `void` |
+| `error` | (`msg`: `string`) => `void` |
+
+#### Returns
+
+`void`
+
+___
+
+### init
+
+▸ **init**(`options`, `success`, `error`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options` | `Partial`\<[`BridgeOptions`](CdvPurchase.AppleAppStore.Bridge.BridgeOptions.md)\> |
+| `success` | () => `void` |
+| `error` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` |
+
+#### Returns
+
+`void`
+
+___
+
+### load
+
+▸ **load**(`productIds`, `success`, `error`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `productIds` | `string`[] |
+| `success` | (`validProducts`: [`ValidProduct`](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md)[], `invalidProductIds`: `string`[]) => `void` |
+| `error` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` |
+
+#### Returns
+
+`void`
+
+___
+
+### loadReceipts
+
+▸ **loadReceipts**(`callback`, `errorCb`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | (`receipt`: [`ApplicationReceipt`](CdvPurchase.AppleAppStore.ApplicationReceipt.md)) => `void` |
+| `errorCb` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` |
+
+#### Returns
+
+`void`
+
+___
+
+### manageBilling
+
+▸ **manageBilling**(`callback?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback?` | [`Callback`](../modules/CdvPurchase.md#callback)\<`any`\> |
+
+#### Returns
+
+`void`
+
+___
+
+### manageSubscriptions
+
+▸ **manageSubscriptions**(`callback?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback?` | [`Callback`](../modules/CdvPurchase.md#callback)\<`any`\> |
+
+#### Returns
+
+`void`
+
+___
+
+### presentCodeRedemptionSheet
+
+▸ **presentCodeRedemptionSheet**(`callback?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback?` | [`Callback`](../modules/CdvPurchase.md#callback)\<`any`\> |
+
+#### Returns
+
+`void`
+
+___
+
+### purchase
+
+▸ **purchase**(`productId`, `quantity`, `applicationUsername`, `discount`, `success`, `error`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `productId` | `string` |
+| `quantity` | `number` |
+| `applicationUsername` | `undefined` \| `string` |
+| `discount` | `undefined` \| [`PaymentDiscount`](CdvPurchase.AppleAppStore.PaymentDiscount.md) |
+| `success` | () => `void` |
+| `error` | () => `void` |
+
+#### Returns
+
+`void`
+
+___
+
+### refreshReceipts
+
+▸ **refreshReceipts**(`successCb`, `errorCb`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `successCb` | (`receipt`: [`ApplicationReceipt`](CdvPurchase.AppleAppStore.ApplicationReceipt.md)) => `void` |
+| `errorCb` | (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void` |
+
+#### Returns
+
+`void`
+
+___
+
+### restore
+
+▸ **restore**(`callback?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback?` | [`Callback`](../modules/CdvPurchase.md#callback)\<`any`\> |
+
+#### Returns
+
+`void`

--- a/api/interfaces/CdvPurchase.AppleAppStore.CdvPurchaseStoreKit2.md
+++ b/api/interfaces/CdvPurchase.AppleAppStore.CdvPurchaseStoreKit2.md
@@ -1,0 +1,24 @@
+# Interface: CdvPurchaseStoreKit2
+
+[CdvPurchase](../modules/CdvPurchase.md).[AppleAppStore](../modules/CdvPurchase.AppleAppStore.md).CdvPurchaseStoreKit2
+
+Global type for the SK2 extension plugin marker
+
+## Table of contents
+
+### Properties
+
+- [installed](CdvPurchase.AppleAppStore.CdvPurchaseStoreKit2.md#installed)
+- [version](CdvPurchase.AppleAppStore.CdvPurchaseStoreKit2.md#version)
+
+## Properties
+
+### installed
+
+• `Optional` **installed**: `boolean`
+
+___
+
+### version
+
+• `Optional` **version**: `string`

--- a/api/interfaces/CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md
+++ b/api/interfaces/CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md
@@ -1,0 +1,348 @@
+# Interface: SK2BridgeCallbacks
+
+[AppleAppStore](../modules/CdvPurchase.AppleAppStore.md).[SK2Bridge](../modules/CdvPurchase.AppleAppStore.SK2Bridge.md).SK2BridgeCallbacks
+
+Extended callbacks with SK2 fields
+
+## Hierarchy
+
+- [`BridgeCallbacks`](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md)
+
+  ↳ **`SK2BridgeCallbacks`**
+
+## Table of contents
+
+### Properties
+
+- [deferred](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#deferred)
+- [error](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#error)
+- [finished](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#finished)
+- [purchaseEnqueued](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#purchaseenqueued)
+- [purchaseFailed](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#purchasefailed)
+- [purchased](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#purchased)
+- [purchasing](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#purchasing)
+- [ready](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#ready)
+- [receiptsRefreshed](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#receiptsrefreshed)
+- [restoreCompleted](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#restorecompleted)
+- [restoreFailed](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#restorefailed)
+- [restored](CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md#restored)
+
+## Properties
+
+### deferred
+
+• **deferred**: (`productId`: `string`) => `void`
+
+Called when a transaction is deferred (waiting for approval)
+
+#### Type declaration
+
+▸ (`productId`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `productId` | `string` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[deferred](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#deferred)
+
+___
+
+### error
+
+• **error**: (`code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`, `options?`: \{ `productId`: `string` ; `quantity?`: `number`  }) => `void`
+
+#### Type declaration
+
+▸ (`code`, `message`, `options?`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `code` | [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md) |
+| `message` | `string` |
+| `options?` | `Object` |
+| `options.productId` | `string` |
+| `options.quantity?` | `number` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[error](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#error)
+
+___
+
+### finished
+
+• **finished**: (`transactionIdentifier`: `string`, `productId`: `string`) => `void`
+
+Called when a transaction is in "finished" state
+
+#### Type declaration
+
+▸ (`transactionIdentifier`, `productId`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transactionIdentifier` | `string` |
+| `productId` | `string` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[finished](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#finished)
+
+___
+
+### purchaseEnqueued
+
+• **purchaseEnqueued**: (`productId`: `string`, `quantity`: `number`) => `void`
+
+Called when a transaction has been enqueued
+
+#### Type declaration
+
+▸ (`productId`, `quantity`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `productId` | `string` |
+| `quantity` | `number` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[purchaseEnqueued](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#purchaseenqueued)
+
+___
+
+### purchaseFailed
+
+• **purchaseFailed**: (`productId`: `string`, `code`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md), `message`: `string`) => `void`
+
+Called when a transaction failed.
+
+Watch out for ErrorCode.PAYMENT_CANCELLED (means user closed the dialog)
+
+#### Type declaration
+
+▸ (`productId`, `code`, `message`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `productId` | `string` |
+| `code` | [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md) |
+| `message` | `string` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[purchaseFailed](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#purchasefailed)
+
+___
+
+### purchased
+
+• **purchased**: (`transactionIdentifier`: `string`, `productId`: `string`, `originalTransactionIdentifier?`: `string`, `transactionDate?`: `string`, `discountId?`: `string`, `expirationDate?`: `string`, `jwsRepresentation?`: `string`) => `void`
+
+Called when a transaction is in "Purchased" state
+
+#### Type declaration
+
+▸ (`transactionIdentifier`, `productId`, `originalTransactionIdentifier?`, `transactionDate?`, `discountId?`, `expirationDate?`, `jwsRepresentation?`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transactionIdentifier` | `string` |
+| `productId` | `string` |
+| `originalTransactionIdentifier?` | `string` |
+| `transactionDate?` | `string` |
+| `discountId?` | `string` |
+| `expirationDate?` | `string` |
+| `jwsRepresentation?` | `string` |
+
+##### Returns
+
+`void`
+
+#### Overrides
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[purchased](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#purchased)
+
+___
+
+### purchasing
+
+• **purchasing**: (`productId`: `string`) => `void`
+
+Called when a transaction is in "purchasing" state
+
+#### Type declaration
+
+▸ (`productId`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `productId` | `string` |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[purchasing](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#purchasing)
+
+___
+
+### ready
+
+• **ready**: () => `void`
+
+Called when the bridge is ready (after setup)
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[ready](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#ready)
+
+___
+
+### receiptsRefreshed
+
+• **receiptsRefreshed**: (`receipt`: [`ApplicationReceipt`](CdvPurchase.AppleAppStore.ApplicationReceipt.md)) => `void`
+
+Called when the application receipt is refreshed
+
+#### Type declaration
+
+▸ (`receipt`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `receipt` | [`ApplicationReceipt`](CdvPurchase.AppleAppStore.ApplicationReceipt.md) |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[receiptsRefreshed](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#receiptsrefreshed)
+
+___
+
+### restoreCompleted
+
+• **restoreCompleted**: () => `void`
+
+Called when a call to "restore" is complete
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[restoreCompleted](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#restorecompleted)
+
+___
+
+### restoreFailed
+
+• **restoreFailed**: (`errorCode`: [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md)) => `void`
+
+Called when a call to "restore" failed
+
+#### Type declaration
+
+▸ (`errorCode`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `errorCode` | [`ErrorCode`](../enums/CdvPurchase.ErrorCode.md) |
+
+##### Returns
+
+`void`
+
+#### Inherited from
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[restoreFailed](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#restorefailed)
+
+___
+
+### restored
+
+• **restored**: (`transactionIdentifier`: `string`, `productId`: `string`, `originalTransactionIdentifier?`: `string`, `transactionDate?`: `string`, `discountId?`: `string`, `expirationDate?`: `string`, `jwsRepresentation?`: `string`) => `void`
+
+Called when a transaction is in "restored" state
+
+#### Type declaration
+
+▸ (`transactionIdentifier`, `productId`, `originalTransactionIdentifier?`, `transactionDate?`, `discountId?`, `expirationDate?`, `jwsRepresentation?`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transactionIdentifier` | `string` |
+| `productId` | `string` |
+| `originalTransactionIdentifier?` | `string` |
+| `transactionDate?` | `string` |
+| `discountId?` | `string` |
+| `expirationDate?` | `string` |
+| `jwsRepresentation?` | `string` |
+
+##### Returns
+
+`void`
+
+#### Overrides
+
+[BridgeCallbacks](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md).[restored](CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md#restored)

--- a/api/interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionAppleSK2.md
+++ b/api/interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionAppleSK2.md
@@ -1,0 +1,37 @@
+# Interface: ApiValidatorBodyTransactionAppleSK2
+
+[Validator](../modules/CdvPurchase.Validator.md).[Request](../modules/CdvPurchase.Validator.Request.md).ApiValidatorBodyTransactionAppleSK2
+
+Transaction type from an Apple device using StoreKit 2
+
+## Table of contents
+
+### Properties
+
+- [id](CdvPurchase.Validator.Request.ApiValidatorBodyTransactionAppleSK2.md#id)
+- [jwsRepresentation](CdvPurchase.Validator.Request.ApiValidatorBodyTransactionAppleSK2.md#jwsrepresentation)
+- [type](CdvPurchase.Validator.Request.ApiValidatorBodyTransactionAppleSK2.md#type)
+
+## Properties
+
+### id
+
+• `Optional` **id**: `string`
+
+Product identifier (e.g. "com.example.premium"), NOT the numeric transaction ID
+
+___
+
+### jwsRepresentation
+
+• **jwsRepresentation**: `string`
+
+JWS representation of the transaction from StoreKit 2
+
+___
+
+### type
+
+• **type**: ``"apple-sk2"``
+
+Value `"apple-sk2"` — distinct from `"ios-appstore"` (SK1)

--- a/api/modules/CdvPurchase.AppleAppStore.Bridge.md
+++ b/api/modules/CdvPurchase.AppleAppStore.Bridge.md
@@ -11,6 +11,7 @@
 ### Interfaces
 
 - [BridgeCallbacks](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeCallbacks.md)
+- [BridgeInterface](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeInterface.md)
 - [BridgeOptions](../interfaces/CdvPurchase.AppleAppStore.Bridge.BridgeOptions.md)
 - [Discount](../interfaces/CdvPurchase.AppleAppStore.Bridge.Discount.md)
 - [ValidProduct](../interfaces/CdvPurchase.AppleAppStore.Bridge.ValidProduct.md)

--- a/api/modules/CdvPurchase.AppleAppStore.SK2Bridge.md
+++ b/api/modules/CdvPurchase.AppleAppStore.SK2Bridge.md
@@ -1,0 +1,13 @@
+# Namespace: SK2Bridge
+
+[CdvPurchase](CdvPurchase.md).[AppleAppStore](CdvPurchase.AppleAppStore.md).SK2Bridge
+
+## Table of contents
+
+### Classes
+
+- [SK2NativeBridge](../classes/CdvPurchase.AppleAppStore.SK2Bridge.SK2NativeBridge.md)
+
+### Interfaces
+
+- [SK2BridgeCallbacks](../interfaces/CdvPurchase.AppleAppStore.SK2Bridge.SK2BridgeCallbacks.md)

--- a/api/modules/CdvPurchase.AppleAppStore.md
+++ b/api/modules/CdvPurchase.AppleAppStore.md
@@ -9,6 +9,7 @@ Apple AppStore adapter using StoreKit version 1
 ### Namespaces
 
 - [Bridge](CdvPurchase.AppleAppStore.Bridge.md)
+- [SK2Bridge](CdvPurchase.AppleAppStore.SK2Bridge.md)
 - [VerifyReceipt](CdvPurchase.AppleAppStore.VerifyReceipt.md)
 
 ### Classes
@@ -24,6 +25,7 @@ Apple AppStore adapter using StoreKit version 1
 - [AdapterOptions](../interfaces/CdvPurchase.AppleAppStore.AdapterOptions.md)
 - [AdditionalData](../interfaces/CdvPurchase.AppleAppStore.AdditionalData.md)
 - [ApplicationReceipt](../interfaces/CdvPurchase.AppleAppStore.ApplicationReceipt.md)
+- [CdvPurchaseStoreKit2](../interfaces/CdvPurchase.AppleAppStore.CdvPurchaseStoreKit2.md)
 - [DiscountEligibilityRequest](../interfaces/CdvPurchase.AppleAppStore.DiscountEligibilityRequest.md)
 - [PaymentDiscount](../interfaces/CdvPurchase.AppleAppStore.PaymentDiscount.md)
 

--- a/api/modules/CdvPurchase.Validator.Request.md
+++ b/api/modules/CdvPurchase.Validator.Request.md
@@ -7,6 +7,7 @@
 ### Interfaces
 
 - [ApiValidatorBodyTransactionApple](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionApple.md)
+- [ApiValidatorBodyTransactionAppleSK2](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionAppleSK2.md)
 - [ApiValidatorBodyTransactionBraintree](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionBraintree.md)
 - [ApiValidatorBodyTransactionGoogle](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionGoogle.md)
 - [ApiValidatorBodyTransactionIaptic](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionIaptic.md)
@@ -25,7 +26,7 @@
 
 ### ApiValidatorBodyTransaction
 
-Ƭ **ApiValidatorBodyTransaction**: [`ApiValidatorBodyTransactionApple`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionApple.md) \| [`ApiValidatorBodyTransactionGoogle`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionGoogle.md) \| [`ApiValidatorBodyTransactionWindows`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionWindows.md) \| [`ApiValidatorBodyTransactionBraintree`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionBraintree.md) \| [`ApiValidatorBodyTransactionIaptic`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionIaptic.md)
+Ƭ **ApiValidatorBodyTransaction**: [`ApiValidatorBodyTransactionApple`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionApple.md) \| [`ApiValidatorBodyTransactionAppleSK2`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionAppleSK2.md) \| [`ApiValidatorBodyTransactionGoogle`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionGoogle.md) \| [`ApiValidatorBodyTransactionWindows`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionWindows.md) \| [`ApiValidatorBodyTransactionBraintree`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionBraintree.md) \| [`ApiValidatorBodyTransactionIaptic`](../interfaces/CdvPurchase.Validator.Request.ApiValidatorBodyTransactionIaptic.md)
 
 ___
 

--- a/api/modules/CdvPurchase.Validator.Response.md
+++ b/api/modules/CdvPurchase.Validator.Response.md
@@ -18,7 +18,7 @@
 
 ### NativeTransaction
 
-Ƭ **NativeTransaction**: \{ `data`: [`TransactionObject`](../interfaces/CdvPurchase.Braintree.TransactionObject.md) ; `type`: ``"braintree"``  } \| \{ `type`: ``"windows-store-transaction"``  } & [`WindowsSubscription`](../interfaces/CdvPurchase.WindowsStore.WindowsSubscription.md) \| \{ `type`: ``"ios-appstore"``  } & [`AppleTransaction`](../interfaces/CdvPurchase.AppleAppStore.VerifyReceipt.AppleTransaction.md) \| [`AppleVerifyReceiptResponseReceipt`](../interfaces/CdvPurchase.AppleAppStore.VerifyReceipt.AppleVerifyReceiptResponseReceipt.md) \| \{ `type`: ``"android-playstore"``  } & [`GooglePurchase`](CdvPurchase.GooglePlay.PublisherAPI.md#googlepurchase) \| \{ `type`: ``"test"``  }
+Ƭ **NativeTransaction**: \{ `data`: [`TransactionObject`](../interfaces/CdvPurchase.Braintree.TransactionObject.md) ; `type`: ``"braintree"``  } \| \{ `type`: ``"windows-store-transaction"``  } & [`WindowsSubscription`](../interfaces/CdvPurchase.WindowsStore.WindowsSubscription.md) \| \{ `type`: ``"ios-appstore"``  } & [`AppleTransaction`](../interfaces/CdvPurchase.AppleAppStore.VerifyReceipt.AppleTransaction.md) \| [`AppleVerifyReceiptResponseReceipt`](../interfaces/CdvPurchase.AppleAppStore.VerifyReceipt.AppleVerifyReceiptResponseReceipt.md) \| \{ `type`: ``"apple-sk2"``  } \| \{ `type`: ``"android-playstore"``  } & [`GooglePurchase`](CdvPurchase.GooglePlay.PublisherAPI.md#googlepurchase) \| \{ `type`: ``"test"``  }
 
 ___
 

--- a/api/modules/CdvPurchase.md
+++ b/api/modules/CdvPurchase.md
@@ -167,7 +167,7 @@ ___
 
 ### PLUGIN\_VERSION
 
-• `Const` **PLUGIN\_VERSION**: ``"13.13.0"``
+• `Const` **PLUGIN\_VERSION**: ``"13.13.1"``
 
 Current release number of the plugin.
 

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -734,17 +734,28 @@ namespace CdvPurchase {
 
                 // SK2 uses a completely different transaction type ('apple-sk2') with JWS
                 // SK1 uses 'ios-appstore' with the monolithic appStoreReceipt
-                const txBody = this.useSK2 && transaction?.jwsRepresentation
-                    ? {
-                        type: 'apple-sk2' as const,
-                        id: transaction?.products?.[0]?.id,
-                        jwsRepresentation: transaction.jwsRepresentation,
+                if (this.useSK2) {
+                    if (!transaction?.jwsRepresentation) {
+                        this.log.warn('SK2 mode but no JWS on transaction, skipping validation');
+                        return undefined;
                     }
-                    : {
-                        type: 'ios-appstore' as const,
-                        id: transaction?.transactionId,
-                        appStoreReceipt: applicationReceipt.appStoreReceipt,
+                    return {
+                        id: applicationReceipt.bundleIdentifier,
+                        type: ProductType.APPLICATION,
+                        products,
+                        transaction: {
+                            type: 'apple-sk2' as const,
+                            id: transaction?.products?.[0]?.id,
+                            jwsRepresentation: transaction.jwsRepresentation,
+                        },
                     };
+                }
+
+                const txBody = {
+                    type: 'ios-appstore' as const,
+                    id: transaction?.transactionId,
+                    appStoreReceipt: applicationReceipt.appStoreReceipt,
+                };
 
                 return {
                     id: applicationReceipt.bundleIdentifier,

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -125,7 +125,10 @@ namespace CdvPurchase {
                 });
             }
 
-            bridge: Bridge.Bridge;
+            bridge: Bridge.BridgeInterface;
+
+            /** True when the StoreKit 2 extension is active */
+            readonly useSK2: boolean;
             context: CdvPurchase.Internal.AdapterContext;
             log: Logger;
 
@@ -146,10 +149,19 @@ namespace CdvPurchase {
 
             constructor(context: CdvPurchase.Internal.AdapterContext, options: AdapterOptions) {
                 this.context = context;
-                this.bridge = new Bridge.Bridge();
                 this.log = context.log.child('AppleAppStore');
+
+                // Use SK2 if extension is installed
+                this.useSK2 = SK2Bridge.SK2NativeBridge.isAvailable();
+                if (this.useSK2) {
+                    this.log.info('StoreKit 2 extension detected, using SK2 bridge');
+                    this.bridge = new SK2Bridge.SK2NativeBridge();
+                } else {
+                    this.bridge = new Bridge.Bridge();
+                }
+
                 this.discountEligibilityDeterminer = options.discountEligibilityDeterminer;
-                this.needAppReceipt = options.needAppReceipt ?? true;
+                this.needAppReceipt = this.useSK2 ? false : (options.needAppReceipt ?? true);
                 this.autoFinish = options.autoFinish ?? false;
                 this.pseudoReceipt = new Receipt(Platform.APPLE_APPSTORE, this.context.apiDecorators);
                 this.receiptsUpdated = Utils.createDebouncer(() => {
@@ -269,11 +281,17 @@ namespace CdvPurchase {
                             this.log.info('ready');
                         },
 
-                        purchased: async (transactionIdentifier: string, productId: string, originalTransactionIdentifier?: string, transactionDate?: string, discountId?: string) => {
-                            this.log.info('purchase: id:' + transactionIdentifier + ' product:' + productId + ' originalTransaction:' + originalTransactionIdentifier + ' - date:' + transactionDate + ' - discount:' + discountId);
+                        purchased: async (transactionIdentifier: string, productId: string,
+                            originalTransactionIdentifier?: string, transactionDate?: string,
+                            discountId?: string, expirationDate?: string, jwsRepresentation?: string) => {
+                            this.log.info('purchase: id:' + transactionIdentifier + ' product:' + productId +
+                                ' originalTransaction:' + originalTransactionIdentifier +
+                                ' - date:' + transactionDate + ' - discount:' + discountId +
+                                (jwsRepresentation ? ' - jws:present' : ''));
                             // we can add the transaction to the receipt here
                             const transaction = await this.upsertTransaction(productId, transactionIdentifier, TransactionState.APPROVED);
-                            transaction.refresh(productId, originalTransactionIdentifier, transactionDate, discountId);
+                            transaction.refresh(productId, originalTransactionIdentifier, transactionDate,
+                                discountId, expirationDate, jwsRepresentation);
                             this.removeTransactionInProgress(productId);
                             this.receiptsUpdated.call();
                             this.callPaymentMonitor('purchased');
@@ -330,9 +348,13 @@ namespace CdvPurchase {
                             this.receiptsUpdated.call();
                         },
 
-                        restored: async (transactionIdentifier: string, productId: string) => {
+                        restored: async (transactionIdentifier: string, productId: string,
+                            originalTransactionIdentifier?: string, transactionDate?: string,
+                            discountId?: string, expirationDate?: string, jwsRepresentation?: string) => {
                             this.log.info('restore: ' + transactionIdentifier + ' - ' + productId);
-                            await this.upsertTransaction(productId, transactionIdentifier, TransactionState.APPROVED);
+                            const transaction = await this.upsertTransaction(productId, transactionIdentifier, TransactionState.APPROVED);
+                            transaction.refresh(productId, originalTransactionIdentifier, transactionDate,
+                                discountId, expirationDate, jwsRepresentation);
                             this.receiptsUpdated.call();
                         },
 
@@ -427,6 +449,17 @@ namespace CdvPurchase {
                     });
                 }
                 if (!nativeData?.appStoreReceipt) {
+                    if (this.useSK2) {
+                        // SK2 doesn't use monolithic receipts — create receipt with empty data
+                        this.log.info('SK2 mode: no appStoreReceipt (expected), creating empty receipt');
+                        this._receipt = new SKApplicationReceipt(
+                            nativeData || { appStoreReceipt: '', bundleIdentifier: '',
+                                bundleShortVersion: '', bundleNumericVersion: 0, bundleSignature: '' },
+                            this.needAppReceipt, this.context.apiDecorators);
+                        this._appStoreReceiptLoading = false;
+                        callCallbacks(undefined);
+                        return;
+                    }
                     this.log.warn('no appStoreReceipt');
                     this._appStoreReceiptLoading = false;
                     callCallbacks(appStoreError(ErrorCode.REFRESH, 'No appStoreReceipt', null));
@@ -635,13 +668,13 @@ namespace CdvPurchase {
                     if (transaction.transactionId === APPLICATION_VIRTUAL_TRANSACTION_ID || transaction.transactionId === virtualTransactionId(transaction.products[0].id)) {
                         // this is a virtual transaction, nothing to do.
                         transaction.state = TransactionState.FINISHED;
-                        this.context.listener.receiptsUpdated(Platform.APPLE_APPSTORE, [transaction.parentReceipt]);
+                        this.receiptsUpdated.call();
                         return resolve(undefined);
                     }
 
                     const success = () => {
                         transaction.state = TransactionState.FINISHED;
-                        this.context.listener.receiptsUpdated(Platform.APPLE_APPSTORE, [transaction.parentReceipt]);
+                        this.receiptsUpdated.call();
                         resolve(undefined);
                     }
                     const error = (msg: string) => {
@@ -683,7 +716,8 @@ namespace CdvPurchase {
                         this.prepareReceipt(nativeData);
                     }
                 }
-                if (!skReceipt.nativeData.appStoreReceipt) {
+                // SK2 doesn't use monolithic receipts — skip the appStoreReceipt check
+                if (!this.useSK2 && !skReceipt.nativeData.appStoreReceipt) {
                     this.log.info('Cannot prepare the receipt validation body, because appStoreReceipt is missing. Refreshing...');
                     const result = await this.refreshReceipt();
                     if (!result || 'isError' in result) {
@@ -695,16 +729,28 @@ namespace CdvPurchase {
                     applicationReceipt = result;
                 }
                 const transaction = skReceipt.transactions.slice(-1)[0] as (SKTransaction | undefined);
+                const products = Utils.objectValues(this.validProducts).map(vp =>
+                    new SKProduct(vp, vp, this.context.apiDecorators, { isEligible: () => true }));
+
+                // SK2 uses a completely different transaction type ('apple-sk2') with JWS
+                // SK1 uses 'ios-appstore' with the monolithic appStoreReceipt
+                const txBody = this.useSK2 && transaction?.jwsRepresentation
+                    ? {
+                        type: 'apple-sk2' as const,
+                        id: transaction?.products?.[0]?.id,
+                        jwsRepresentation: transaction.jwsRepresentation,
+                    }
+                    : {
+                        type: 'ios-appstore' as const,
+                        id: transaction?.transactionId,
+                        appStoreReceipt: applicationReceipt.appStoreReceipt,
+                    };
+
                 return {
                     id: applicationReceipt.bundleIdentifier,
                     type: ProductType.APPLICATION,
-                    // send all products and offers so validator get pricing information
-                    products: Utils.objectValues(this.validProducts).map(vp => new SKProduct(vp, vp, this.context.apiDecorators, { isEligible: () => true })),
-                    transaction: {
-                        type: 'ios-appstore',
-                        id: transaction?.transactionId,
-                        appStoreReceipt: applicationReceipt.appStoreReceipt,
-                    }
+                    products,
+                    transaction: txBody,
                 }
             }
 
@@ -713,7 +759,8 @@ namespace CdvPurchase {
                 let localReceiptUpdated = false;
                 if (response.ok) {
                     const vTransaction = response.data?.transaction;
-                    if (vTransaction?.type === 'ios-appstore' && 'original_application_version' in vTransaction) {
+                    const isApple = vTransaction?.type === 'ios-appstore' || vTransaction?.type === 'apple-sk2';
+                    if (isApple && vTransaction && 'original_application_version' in vTransaction) {
                         this._receipt?.transactions.forEach(t => {
                             if (t.transactionId === APPLICATION_VIRTUAL_TRANSACTION_ID) {
                                 if (vTransaction.original_purchase_date_ms) {

--- a/src/ts/platforms/apple-appstore/appstore-bridge-interface.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-interface.ts
@@ -1,0 +1,48 @@
+namespace CdvPurchase {
+    export namespace AppleAppStore {
+
+        /** Global type for the SK2 extension plugin marker */
+        export interface CdvPurchaseStoreKit2 {
+            installed?: boolean;
+            version?: string;
+        }
+
+        export namespace Bridge {
+
+            /**
+             * Shared interface implemented by both the SK1 and SK2 bridges.
+             * The adapter programs against this interface, not a concrete class.
+             */
+            export interface BridgeInterface {
+                /** Cached app store receipt */
+                appStoreReceipt?: ApplicationReceipt | null;
+                /** Transaction IDs grouped by product */
+                transactionsForProduct: { [productId: string]: string[] };
+                /** Whether this bridge uses StoreKit 2 */
+                readonly isSK2?: boolean;
+
+                init(options: Partial<BridgeOptions>, success: () => void,
+                     error: (code: ErrorCode, message: string) => void): void;
+                load(productIds: string[],
+                     success: (validProducts: ValidProduct[], invalidProductIds: string[]) => void,
+                     error: (code: ErrorCode, message: string) => void): void;
+                purchase(productId: string, quantity: number,
+                         applicationUsername: string | undefined,
+                         discount: PaymentDiscount | undefined,
+                         success: () => void, error: () => void): void;
+                finish(transactionId: string, success: () => void,
+                       error: (msg: string) => void): void;
+                canMakePayments(success: () => void,
+                                error: (message: string) => void): void;
+                restore(callback?: Callback<any>): void;
+                manageSubscriptions(callback?: Callback<any>): void;
+                manageBilling(callback?: Callback<any>): void;
+                presentCodeRedemptionSheet(callback?: Callback<any>): void;
+                refreshReceipts(successCb: (receipt: ApplicationReceipt) => void,
+                                errorCb: (code: ErrorCode, message: string) => void): void;
+                loadReceipts(callback: (receipt: ApplicationReceipt) => void,
+                             errorCb: (code: ErrorCode, message: string) => void): void;
+            }
+        }
+    }
+}

--- a/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
@@ -1,0 +1,364 @@
+namespace CdvPurchase {
+    export namespace AppleAppStore {
+
+        export namespace SK2Bridge {
+
+            const noop = (args?: any) => {};
+            let log: (message: string) => void = noop;
+
+            function exec(methodName: string, options: any[],
+                          success?: (msg?: any) => void,
+                          error?: (err: string) => void) {
+                window.cordova.exec(success, error, "StoreKit2Plugin", methodName, options);
+            }
+
+            function protectCall<T extends (...args: any) => any>(
+                this: any, callback: T, context: string, ...args: Parameters<T>) {
+                if (!callback) return;
+                try {
+                    callback.apply(this, args);
+                } catch (err) {
+                    log('exception in ' + context + ': "' + err + '"');
+                }
+            }
+
+            /** Extended callbacks with SK2 fields */
+            export interface SK2BridgeCallbacks extends Bridge.BridgeCallbacks {
+                purchased: (transactionIdentifier: string, productId: string,
+                    originalTransactionIdentifier?: string, transactionDate?: string,
+                    discountId?: string, expirationDate?: string,
+                    jwsRepresentation?: string) => void;
+                restored: (transactionIdentifier: string, productId: string,
+                    originalTransactionIdentifier?: string, transactionDate?: string,
+                    discountId?: string, expirationDate?: string,
+                    jwsRepresentation?: string) => void;
+            }
+
+            export class SK2NativeBridge implements Bridge.BridgeInterface {
+
+                options: SK2BridgeCallbacks;
+                transactionsForProduct: { [productId: string]: string[] } = {};
+                private initialized = false;
+                appStoreReceipt?: AppleAppStore.ApplicationReceipt | null;
+                private registeredProducts: string[] = [];
+                private needRestoreNotification = false;
+                private pendingUpdates: {
+                    state: Bridge.TransactionState;
+                    errorCode: ErrorCode | undefined;
+                    errorText: string | undefined;
+                    transactionIdentifier: string;
+                    productId: string;
+                    transactionReceipt: never;
+                    originalTransactionIdentifier: string | undefined;
+                    transactionDate: string | undefined;
+                    discountId: string | undefined;
+                    expirationDate: string | undefined;
+                    jwsRepresentation: string | undefined;
+                }[] = [];
+
+                /** True when this bridge is active (SK2 extension installed + iOS 15+) */
+                readonly isSK2 = true;
+
+                constructor() {
+                    (window as any).storekit2 = this;
+
+                    this.options = {
+                        error: noop,
+                        ready: noop,
+                        purchased: noop,
+                        purchaseEnqueued: noop,
+                        purchasing: noop,
+                        purchaseFailed: noop,
+                        deferred: noop,
+                        finished: noop,
+                        restored: noop,
+                        receiptsRefreshed: noop,
+                        restoreFailed: noop,
+                        restoreCompleted: noop,
+                    };
+                }
+
+                /** Check if the SK2 extension plugin is installed */
+                static isAvailable(): boolean {
+                    // Check marker from the extension plugin
+                    const marker = (window as any).CdvPurchaseStoreKit2;
+                    return !!(marker && marker.installed);
+                }
+
+                init(options: Partial<Bridge.BridgeOptions>,
+                     success: () => void,
+                     error: (code: ErrorCode, message: string) => void) {
+                    this.options = {
+                        error: options.error || noop,
+                        ready: options.ready || noop,
+                        purchased: options.purchased || noop,
+                        purchaseEnqueued: options.purchaseEnqueued || noop,
+                        purchasing: options.purchasing || noop,
+                        purchaseFailed: options.purchaseFailed || noop,
+                        deferred: options.deferred || noop,
+                        finished: options.finished || noop,
+                        restored: options.restored || noop,
+                        receiptsRefreshed: options.receiptsRefreshed || noop,
+                        restoreFailed: options.restoreFailed || noop,
+                        restoreCompleted: options.restoreCompleted || noop,
+                    };
+
+                    if (options.debug) {
+                        exec('debug', [], noop, noop);
+                        log = options.log || function(msg) {
+                            console.log("[CdvPurchase.AppleAppStore.SK2Bridge] " + msg);
+                        };
+                    }
+
+                    if (options.autoFinish) {
+                        exec('autoFinish', [], noop, noop);
+                    }
+
+                    const setupOk = () => {
+                        log('setup ok');
+                        protectCall(this.options.ready, 'options.ready');
+                        protectCall(success, 'init.success');
+                        this.initialized = true;
+                        setTimeout(() => this.processPendingTransactions(), 50);
+                    };
+
+                    const setupFailed = (err: string) => {
+                        log('setup failed');
+                        protectCall(error, 'init.error', ErrorCode.SETUP, 'Setup failed: ' + err);
+                    };
+
+                    exec('setup', [], setupOk, setupFailed);
+                }
+
+                processPendingTransactions() {
+                    log('processing pending transactions');
+                    exec('processPendingTransactions', [], () => {
+                        this.finalizeTransactionUpdates();
+                    }, undefined);
+                }
+
+                purchase(productId: string, quantity: number,
+                         applicationUsername: string | undefined,
+                         discount: PaymentDiscount | undefined,
+                         success: () => void, error: () => void) {
+                    quantity = (quantity | 0) || 1;
+                    const options = this.options;
+
+                    if (this.registeredProducts.indexOf(productId) < 0) {
+                        const msg = 'Purchasing ' + productId + ' failed. Ensure the product was loaded first with load()!';
+                        log(msg);
+                        if (typeof options.error === 'function') {
+                            protectCall(options.error, 'options.error', ErrorCode.PURCHASE,
+                                'Trying to purchase an unknown product.', { productId, quantity });
+                        }
+                        return;
+                    }
+
+                    const purchaseOk = () => {
+                        log('Purchase enqueued ' + productId);
+                        if (typeof options.purchaseEnqueued === 'function') {
+                            protectCall(options.purchaseEnqueued, 'options.purchaseEnqueued',
+                                productId, quantity);
+                        }
+                        protectCall(success, 'purchase.success');
+                    };
+                    const purchaseFailed = () => {
+                        const errMsg = 'Purchase failed: ' + productId;
+                        log(errMsg);
+                        if (typeof options.error === 'function') {
+                            protectCall(options.error, 'options.error', ErrorCode.PURCHASE,
+                                errMsg, { productId, quantity });
+                        }
+                        protectCall(error, 'purchase.error');
+                    };
+                    exec('purchase', [productId, quantity, applicationUsername, discount || {}],
+                        purchaseOk, purchaseFailed);
+                }
+
+                canMakePayments(success: () => void, error: (message: string) => void) {
+                    return exec("canMakePayments", [], success, error);
+                }
+
+                restore(callback?: Callback<any>) {
+                    this.needRestoreNotification = true;
+                    exec('restoreCompletedTransactions', [], callback, callback);
+                }
+
+                manageSubscriptions(callback?: Callback<any>) {
+                    exec('manageSubscriptions', [], callback, callback);
+                }
+
+                manageBilling(callback?: Callback<any>) {
+                    exec('manageBilling', [], callback, callback);
+                }
+
+                presentCodeRedemptionSheet(callback?: Callback<any>) {
+                    exec('presentCodeRedemptionSheet', [], callback, callback);
+                }
+
+                load(productIds: string[],
+                     success: (validProducts: Bridge.ValidProduct[],
+                               invalidProductIds: string[]) => void,
+                     error: (code: ErrorCode, message: string) => void) {
+                    const options = this.options;
+                    if (!productIds || !productIds.length) {
+                        protectCall(success, 'load.success', [], []);
+                        return;
+                    }
+
+                    log('load ' + JSON.stringify(productIds));
+
+                    const loadOk = (array: [Bridge.ValidProduct[], string[]]) => {
+                        const valid = array[0];
+                        const invalid = array[1];
+                        log('load ok: { valid:' + JSON.stringify(valid) + ' invalid:' + JSON.stringify(invalid) + ' }');
+                        protectCall(success, 'load.success', valid, invalid);
+                    };
+                    const loadFailed = (errMessage: string) => {
+                        log('load failed: ' + errMessage);
+                        protectCall(options.error, 'options.error', ErrorCode.LOAD, 'Load failed: ' + errMessage);
+                        protectCall(error, 'load.error', ErrorCode.LOAD, 'Load failed: ' + errMessage);
+                    };
+
+                    this.registeredProducts = this.registeredProducts.concat(productIds);
+                    exec('load', [productIds], loadOk, loadFailed);
+                }
+
+                finish(transactionId: string, success: () => void, error: (msg: string) => void) {
+                    exec('finishTransaction', [transactionId], success, error);
+                }
+
+                finalizeTransactionUpdates() {
+                    for (let i = 0; i < this.pendingUpdates.length; ++i) {
+                        const args = this.pendingUpdates[i];
+                        this.transactionUpdated(args.state, args.errorCode, args.errorText,
+                            args.transactionIdentifier, args.productId, args.transactionReceipt,
+                            args.originalTransactionIdentifier, args.transactionDate,
+                            args.discountId, args.expirationDate, args.jwsRepresentation);
+                    }
+                    this.pendingUpdates = [];
+                }
+
+                lastTransactionUpdated() {
+                    // no more pending transactions
+                }
+
+                /** Called from native. Same as SK1 but with extra SK2 fields. */
+                transactionUpdated(
+                    state: Bridge.TransactionState,
+                    errorCode: ErrorCode | undefined,
+                    errorText: string | undefined,
+                    transactionIdentifier: string,
+                    productId: string,
+                    transactionReceipt: never,
+                    originalTransactionIdentifier: string | undefined,
+                    transactionDate: string | undefined,
+                    discountId: string | undefined,
+                    expirationDate?: string | undefined,
+                    jwsRepresentation?: string | undefined
+                ) {
+                    if (!this.initialized) {
+                        this.pendingUpdates.push({
+                            state, errorCode, errorText, transactionIdentifier,
+                            productId, transactionReceipt, originalTransactionIdentifier,
+                            transactionDate, discountId, expirationDate, jwsRepresentation
+                        });
+                        return;
+                    }
+                    log("transaction updated:" + transactionIdentifier +
+                        " state:" + state + " product:" + productId);
+
+                    if (productId && transactionIdentifier) {
+                        if (this.transactionsForProduct[productId]) {
+                            this.transactionsForProduct[productId].push(transactionIdentifier);
+                        } else {
+                            this.transactionsForProduct[productId] = [transactionIdentifier];
+                        }
+                    }
+
+                    switch (state) {
+                        case "PaymentTransactionStatePurchasing":
+                            protectCall(this.options.purchasing, 'options.purchasing', productId);
+                            return;
+                        case "PaymentTransactionStatePurchased":
+                            protectCall(this.options.purchased, 'options.purchased',
+                                transactionIdentifier, productId,
+                                originalTransactionIdentifier, transactionDate,
+                                discountId, expirationDate, jwsRepresentation);
+                            return;
+                        case "PaymentTransactionStateDeferred":
+                            protectCall(this.options.deferred, 'options.deferred', productId);
+                            return;
+                        case "PaymentTransactionStateFailed":
+                            protectCall(this.options.purchaseFailed, 'options.purchaseFailed',
+                                productId, errorCode || ErrorCode.UNKNOWN, errorText || 'ERROR');
+                            protectCall(this.options.error, 'options.error',
+                                errorCode || ErrorCode.UNKNOWN, errorText || 'ERROR', { productId });
+                            return;
+                        case "PaymentTransactionStateRestored":
+                            protectCall(this.options.restored, 'options.restored',
+                                transactionIdentifier, productId,
+                                originalTransactionIdentifier, transactionDate,
+                                discountId, expirationDate, jwsRepresentation);
+                            return;
+                        case "PaymentTransactionStateFinished":
+                            protectCall(this.options.finished, 'options.finished',
+                                transactionIdentifier, productId);
+                            return;
+                    }
+                }
+
+                restoreCompletedTransactionsFinished() {
+                    if (!this.needRestoreNotification) return;
+                    this.needRestoreNotification = false;
+                    protectCall(this.options.restoreCompleted, 'options.restoreCompleted');
+                }
+
+                restoreCompletedTransactionsFailed(errorCode: ErrorCode) {
+                    if (!this.needRestoreNotification) return;
+                    this.needRestoreNotification = false;
+                    protectCall(this.options.restoreFailed, 'options.restoreFailed', errorCode);
+                }
+
+                parseReceiptArgs(args: [string, string, string, number, string]):
+                    ApplicationReceipt {
+                    return {
+                        appStoreReceipt: args[0],
+                        bundleIdentifier: args[1],
+                        bundleShortVersion: args[2],
+                        bundleNumericVersion: args[3],
+                        bundleSignature: args[4],
+                    };
+                }
+
+                refreshReceipts(successCb: (receipt: ApplicationReceipt) => void,
+                                errorCb: (code: ErrorCode, message: string) => void) {
+                    const loaded = (args: [string, string, string, number, string]) => {
+                        const data = this.parseReceiptArgs(args);
+                        this.appStoreReceipt = data;
+                        protectCall(this.options.receiptsRefreshed, 'options.receiptsRefreshed', data);
+                        protectCall(successCb, "refreshReceipts.success", data);
+                    };
+                    const error = (errMessage: string) => {
+                        log('refresh receipt failed: ' + errMessage);
+                        protectCall(errorCb, "refreshReceipts.error",
+                            ErrorCode.REFRESH_RECEIPTS, 'Failed to refresh receipt: ' + errMessage);
+                    };
+                    this.appStoreReceipt = null;
+                    exec('appStoreRefreshReceipt', [], loaded, error);
+                }
+
+                loadReceipts(callback: (receipt: ApplicationReceipt) => void,
+                             errorCb: (code: ErrorCode, message: string) => void) {
+                    const loaded = (args: [string, string, string, number, string]) => {
+                        const data = this.parseReceiptArgs(args);
+                        this.appStoreReceipt = data;
+                        protectCall(callback, 'loadReceipts.callback', data);
+                    };
+                    log('loading appStoreReceipt (SK2)');
+                    exec('appStoreReceipt', [], loaded, undefined);
+                }
+            }
+        }
+    }
+}

--- a/src/ts/platforms/apple-appstore/appstore-bridge.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge.ts
@@ -223,7 +223,7 @@ namespace CdvPurchase {
                 autoFinish: boolean;
             }
 
-            export class Bridge {
+            export class Bridge implements BridgeInterface {
 
                 /** Callbacks set by the adapter */
                 options: BridgeCallbacks;

--- a/src/ts/platforms/apple-appstore/appstore-receipt.ts
+++ b/src/ts/platforms/apple-appstore/appstore-receipt.ts
@@ -41,11 +41,17 @@ namespace CdvPurchase {
     export class SKTransaction extends Transaction {
 
         originalTransactionId?: string;
+        /** JWS representation of the transaction (StoreKit 2 only) */
+        jwsRepresentation?: string;
 
-        refresh(productId?: string, originalTransactionIdentifier?: string, transactionDate?: string, discountId?: string) {
+        refresh(productId?: string, originalTransactionIdentifier?: string,
+                transactionDate?: string, discountId?: string,
+                expirationDateMs?: string, jwsRepresentation?: string) {
             if (productId) this.products = [{ id: productId, offerId: discountId }];
             if (originalTransactionIdentifier) this.originalTransactionId = originalTransactionIdentifier;
             if (transactionDate) this.purchaseDate = new Date(+transactionDate);
+            if (expirationDateMs) this.expirationDate = new Date(+expirationDateMs);
+            if (jwsRepresentation) this.jwsRepresentation = jwsRepresentation;
         }
     }
   }

--- a/src/ts/validator/validator-request.ts
+++ b/src/ts/validator/validator-request.ts
@@ -107,6 +107,7 @@ namespace CdvPurchase {
 
             export type ApiValidatorBodyTransaction =
                 | ApiValidatorBodyTransactionApple
+                | ApiValidatorBodyTransactionAppleSK2
                 | ApiValidatorBodyTransactionGoogle
                 | ApiValidatorBodyTransactionWindows
                 | ApiValidatorBodyTransactionBraintree
@@ -138,6 +139,16 @@ namespace CdvPurchase {
                  * @deprecated Use `appStoreReceipt`
                  */
                 transactionReceipt?: never;
+            }
+
+            /** Transaction type from an Apple device using StoreKit 2 */
+            export interface ApiValidatorBodyTransactionAppleSK2 {
+                /** Value `"apple-sk2"` — distinct from `"ios-appstore"` (SK1) */
+                type: 'apple-sk2';
+                /** Product identifier (e.g. "com.example.premium"), NOT the numeric transaction ID */
+                id?: string;
+                /** JWS representation of the transaction from StoreKit 2 */
+                jwsRepresentation: string;
             }
 
             /** Transaction type from a google powered device  */

--- a/src/ts/validator/validator-response.ts
+++ b/src/ts/validator/validator-response.ts
@@ -41,6 +41,7 @@ namespace CdvPurchase {
                 | ({ type: 'braintree'; data: Braintree.TransactionObject})
                 | ({ type: 'windows-store-transaction' } & WindowsStore.WindowsSubscription)
                 | ({ type: 'ios-appstore'; } & (AppleAppStore.VerifyReceipt.AppleTransaction | AppleAppStore.VerifyReceipt.AppleVerifyReceiptResponseReceipt))
+                | ({ type: 'apple-sk2'; })
                 | ({ type: 'android-playstore'; } & GooglePlay.PublisherAPI.GooglePurchase)
                 | ({ type: 'test'; })
                 //  | ({ type: 'stripe-charge'; } & StripeCharge);

--- a/www/store.d.ts
+++ b/www/store.d.ts
@@ -817,7 +817,7 @@ declare namespace CdvPurchase {
     /**
      * Current release number of the plugin.
      */
-    const PLUGIN_VERSION = "13.13.0";
+    const PLUGIN_VERSION = "13.13.1";
     /**
      * Entry class of the plugin.
      */
@@ -2570,7 +2570,9 @@ declare namespace CdvPurchase {
             get receipts(): Receipt[];
             private validProducts;
             addValidProducts(registerProducts: IRegisterProduct[], validProducts: Bridge.ValidProduct[]): void;
-            bridge: Bridge.Bridge;
+            bridge: Bridge.BridgeInterface;
+            /** True when the StoreKit 2 extension is active */
+            readonly useSK2: boolean;
             context: CdvPurchase.Internal.AdapterContext;
             log: Logger;
             /** Component that determine eligibility to a given discount offer */
@@ -2626,6 +2628,88 @@ declare namespace CdvPurchase {
             checkSupport(functionality: PlatformFunctionality): boolean;
             restorePurchases(): Promise<IError | undefined>;
             presentCodeRedemptionSheet(): Promise<void>;
+        }
+    }
+}
+declare namespace CdvPurchase {
+    namespace AppleAppStore {
+        /** Global type for the SK2 extension plugin marker */
+        interface CdvPurchaseStoreKit2 {
+            installed?: boolean;
+            version?: string;
+        }
+        namespace Bridge {
+            /**
+             * Shared interface implemented by both the SK1 and SK2 bridges.
+             * The adapter programs against this interface, not a concrete class.
+             */
+            interface BridgeInterface {
+                /** Cached app store receipt */
+                appStoreReceipt?: ApplicationReceipt | null;
+                /** Transaction IDs grouped by product */
+                transactionsForProduct: {
+                    [productId: string]: string[];
+                };
+                /** Whether this bridge uses StoreKit 2 */
+                readonly isSK2?: boolean;
+                init(options: Partial<BridgeOptions>, success: () => void, error: (code: ErrorCode, message: string) => void): void;
+                load(productIds: string[], success: (validProducts: ValidProduct[], invalidProductIds: string[]) => void, error: (code: ErrorCode, message: string) => void): void;
+                purchase(productId: string, quantity: number, applicationUsername: string | undefined, discount: PaymentDiscount | undefined, success: () => void, error: () => void): void;
+                finish(transactionId: string, success: () => void, error: (msg: string) => void): void;
+                canMakePayments(success: () => void, error: (message: string) => void): void;
+                restore(callback?: Callback<any>): void;
+                manageSubscriptions(callback?: Callback<any>): void;
+                manageBilling(callback?: Callback<any>): void;
+                presentCodeRedemptionSheet(callback?: Callback<any>): void;
+                refreshReceipts(successCb: (receipt: ApplicationReceipt) => void, errorCb: (code: ErrorCode, message: string) => void): void;
+                loadReceipts(callback: (receipt: ApplicationReceipt) => void, errorCb: (code: ErrorCode, message: string) => void): void;
+            }
+        }
+    }
+}
+declare namespace CdvPurchase {
+    namespace AppleAppStore {
+        namespace SK2Bridge {
+            /** Extended callbacks with SK2 fields */
+            interface SK2BridgeCallbacks extends Bridge.BridgeCallbacks {
+                purchased: (transactionIdentifier: string, productId: string, originalTransactionIdentifier?: string, transactionDate?: string, discountId?: string, expirationDate?: string, jwsRepresentation?: string) => void;
+                restored: (transactionIdentifier: string, productId: string, originalTransactionIdentifier?: string, transactionDate?: string, discountId?: string, expirationDate?: string, jwsRepresentation?: string) => void;
+            }
+            class SK2NativeBridge implements Bridge.BridgeInterface {
+                options: SK2BridgeCallbacks;
+                transactionsForProduct: {
+                    [productId: string]: string[];
+                };
+                private initialized;
+                appStoreReceipt?: AppleAppStore.ApplicationReceipt | null;
+                private registeredProducts;
+                private needRestoreNotification;
+                private pendingUpdates;
+                /** True when this bridge is active (SK2 extension installed + iOS 15+) */
+                readonly isSK2 = true;
+                constructor();
+                /** Check if the SK2 extension plugin is installed */
+                static isAvailable(): boolean;
+                init(options: Partial<Bridge.BridgeOptions>, success: () => void, error: (code: ErrorCode, message: string) => void): void;
+                processPendingTransactions(): void;
+                purchase(productId: string, quantity: number, applicationUsername: string | undefined, discount: PaymentDiscount | undefined, success: () => void, error: () => void): void;
+                canMakePayments(success: () => void, error: (message: string) => void): void;
+                restore(callback?: Callback<any>): void;
+                manageSubscriptions(callback?: Callback<any>): void;
+                manageBilling(callback?: Callback<any>): void;
+                presentCodeRedemptionSheet(callback?: Callback<any>): void;
+                load(productIds: string[], success: (validProducts: Bridge.ValidProduct[], invalidProductIds: string[]) => void, error: (code: ErrorCode, message: string) => void): void;
+                finish(transactionId: string, success: () => void, error: (msg: string) => void): void;
+                finalizeTransactionUpdates(): void;
+                lastTransactionUpdated(): void;
+                /** Called from native. Same as SK1 but with extra SK2 fields. */
+                transactionUpdated(state: Bridge.TransactionState, errorCode: ErrorCode | undefined, errorText: string | undefined, transactionIdentifier: string, productId: string, transactionReceipt: never, originalTransactionIdentifier: string | undefined, transactionDate: string | undefined, discountId: string | undefined, expirationDate?: string | undefined, jwsRepresentation?: string | undefined): void;
+                restoreCompletedTransactionsFinished(): void;
+                restoreCompletedTransactionsFailed(errorCode: ErrorCode): void;
+                parseReceiptArgs(args: [string, string, string, number, string]): ApplicationReceipt;
+                refreshReceipts(successCb: (receipt: ApplicationReceipt) => void, errorCb: (code: ErrorCode, message: string) => void): void;
+                loadReceipts(callback: (receipt: ApplicationReceipt) => void, errorCb: (code: ErrorCode, message: string) => void): void;
+            }
         }
     }
 }
@@ -2775,7 +2859,7 @@ declare namespace CdvPurchase {
                 /** Auto-finish transaction */
                 autoFinish: boolean;
             }
-            export class Bridge {
+            export class Bridge implements BridgeInterface {
                 /** Callbacks set by the adapter */
                 options: BridgeCallbacks;
                 /** Transactions for a given product */
@@ -2938,7 +3022,9 @@ declare namespace CdvPurchase {
         /** StoreKit transaction */
         class SKTransaction extends Transaction {
             originalTransactionId?: string;
-            refresh(productId?: string, originalTransactionIdentifier?: string, transactionDate?: string, discountId?: string): void;
+            /** JWS representation of the transaction (StoreKit 2 only) */
+            jwsRepresentation?: string;
+            refresh(productId?: string, originalTransactionIdentifier?: string, transactionDate?: string, discountId?: string, expirationDateMs?: string, jwsRepresentation?: string): void;
         }
     }
 }
@@ -5865,7 +5951,7 @@ declare namespace CdvPurchase {
                     }[];
                 }[];
             }
-            type ApiValidatorBodyTransaction = ApiValidatorBodyTransactionApple | ApiValidatorBodyTransactionGoogle | ApiValidatorBodyTransactionWindows | ApiValidatorBodyTransactionBraintree | ApiValidatorBodyTransactionIaptic;
+            type ApiValidatorBodyTransaction = ApiValidatorBodyTransactionApple | ApiValidatorBodyTransactionAppleSK2 | ApiValidatorBodyTransactionGoogle | ApiValidatorBodyTransactionWindows | ApiValidatorBodyTransactionBraintree | ApiValidatorBodyTransactionIaptic;
             interface ApiValidatorBodyTransactionIaptic {
                 type: 'iaptic';
                 /** The backend adapter type (e.g., 'stripe') */
@@ -5887,6 +5973,15 @@ declare namespace CdvPurchase {
                  * @deprecated Use `appStoreReceipt`
                  */
                 transactionReceipt?: never;
+            }
+            /** Transaction type from an Apple device using StoreKit 2 */
+            interface ApiValidatorBodyTransactionAppleSK2 {
+                /** Value `"apple-sk2"` — distinct from `"ios-appstore"` (SK1) */
+                type: 'apple-sk2';
+                /** Product identifier (e.g. "com.example.premium"), NOT the numeric transaction ID */
+                id?: string;
+                /** JWS representation of the transaction from StoreKit 2 */
+                jwsRepresentation: string;
             }
             /** Transaction type from a google powered device  */
             interface ApiValidatorBodyTransactionGoogle {
@@ -6017,6 +6112,8 @@ declare namespace CdvPurchase {
             } & WindowsStore.WindowsSubscription) | ({
                 type: 'ios-appstore';
             } & (AppleAppStore.VerifyReceipt.AppleTransaction | AppleAppStore.VerifyReceipt.AppleVerifyReceiptResponseReceipt)) | ({
+                type: 'apple-sk2';
+            }) | ({
                 type: 'android-playstore';
             } & GooglePlay.PublisherAPI.GooglePurchase) | ({
                 type: 'test';

--- a/www/store.js
+++ b/www/store.js
@@ -2884,10 +2884,18 @@ var CdvPurchase;
                 /** List of functions waiting for the appStoreReceipt to be initialized */
                 this._appStoreReceiptCallbacks = [];
                 this.context = context;
-                this.bridge = new AppleAppStore.Bridge.Bridge();
                 this.log = context.log.child('AppleAppStore');
+                // Use SK2 if extension is installed
+                this.useSK2 = AppleAppStore.SK2Bridge.SK2NativeBridge.isAvailable();
+                if (this.useSK2) {
+                    this.log.info('StoreKit 2 extension detected, using SK2 bridge');
+                    this.bridge = new AppleAppStore.SK2Bridge.SK2NativeBridge();
+                }
+                else {
+                    this.bridge = new AppleAppStore.Bridge.Bridge();
+                }
                 this.discountEligibilityDeterminer = options.discountEligibilityDeterminer;
-                this.needAppReceipt = (_a = options.needAppReceipt) !== null && _a !== void 0 ? _a : true;
+                this.needAppReceipt = this.useSK2 ? false : ((_a = options.needAppReceipt) !== null && _a !== void 0 ? _a : true);
                 this.autoFinish = (_b = options.autoFinish) !== null && _b !== void 0 ? _b : false;
                 this.pseudoReceipt = new CdvPurchase.Receipt(CdvPurchase.Platform.APPLE_APPSTORE, this.context.apiDecorators);
                 this.receiptsUpdated = CdvPurchase.Utils.createDebouncer(() => {
@@ -3015,11 +3023,14 @@ var CdvPurchase;
                         ready: () => {
                             this.log.info('ready');
                         },
-                        purchased: (transactionIdentifier, productId, originalTransactionIdentifier, transactionDate, discountId) => __awaiter(this, void 0, void 0, function* () {
-                            this.log.info('purchase: id:' + transactionIdentifier + ' product:' + productId + ' originalTransaction:' + originalTransactionIdentifier + ' - date:' + transactionDate + ' - discount:' + discountId);
+                        purchased: (transactionIdentifier, productId, originalTransactionIdentifier, transactionDate, discountId, expirationDate, jwsRepresentation) => __awaiter(this, void 0, void 0, function* () {
+                            this.log.info('purchase: id:' + transactionIdentifier + ' product:' + productId +
+                                ' originalTransaction:' + originalTransactionIdentifier +
+                                ' - date:' + transactionDate + ' - discount:' + discountId +
+                                (jwsRepresentation ? ' - jws:present' : ''));
                             // we can add the transaction to the receipt here
                             const transaction = yield this.upsertTransaction(productId, transactionIdentifier, CdvPurchase.TransactionState.APPROVED);
-                            transaction.refresh(productId, originalTransactionIdentifier, transactionDate, discountId);
+                            transaction.refresh(productId, originalTransactionIdentifier, transactionDate, discountId, expirationDate, jwsRepresentation);
                             this.removeTransactionInProgress(productId);
                             this.receiptsUpdated.call();
                             this.callPaymentMonitor('purchased');
@@ -3070,9 +3081,10 @@ var CdvPurchase;
                             yield this.upsertTransaction(productId, transactionIdentifier, CdvPurchase.TransactionState.FINISHED);
                             this.receiptsUpdated.call();
                         }),
-                        restored: (transactionIdentifier, productId) => __awaiter(this, void 0, void 0, function* () {
+                        restored: (transactionIdentifier, productId, originalTransactionIdentifier, transactionDate, discountId, expirationDate, jwsRepresentation) => __awaiter(this, void 0, void 0, function* () {
                             this.log.info('restore: ' + transactionIdentifier + ' - ' + productId);
-                            yield this.upsertTransaction(productId, transactionIdentifier, CdvPurchase.TransactionState.APPROVED);
+                            const transaction = yield this.upsertTransaction(productId, transactionIdentifier, CdvPurchase.TransactionState.APPROVED);
+                            transaction.refresh(productId, originalTransactionIdentifier, transactionDate, discountId, expirationDate, jwsRepresentation);
                             this.receiptsUpdated.call();
                         }),
                         receiptsRefreshed: (receipt) => {
@@ -3157,6 +3169,15 @@ var CdvPurchase;
                         });
                     };
                     if (!(nativeData === null || nativeData === void 0 ? void 0 : nativeData.appStoreReceipt)) {
+                        if (this.useSK2) {
+                            // SK2 doesn't use monolithic receipts — create receipt with empty data
+                            this.log.info('SK2 mode: no appStoreReceipt (expected), creating empty receipt');
+                            this._receipt = new AppleAppStore.SKApplicationReceipt(nativeData || { appStoreReceipt: '', bundleIdentifier: '',
+                                bundleShortVersion: '', bundleNumericVersion: 0, bundleSignature: '' }, this.needAppReceipt, this.context.apiDecorators);
+                            this._appStoreReceiptLoading = false;
+                            callCallbacks(undefined);
+                            return;
+                        }
                         this.log.warn('no appStoreReceipt');
                         this._appStoreReceiptLoading = false;
                         callCallbacks(appStoreError(CdvPurchase.ErrorCode.REFRESH, 'No appStoreReceipt', null));
@@ -3403,6 +3424,7 @@ var CdvPurchase;
                 });
             }
             receiptValidationBody(receipt) {
+                var _a, _b;
                 return __awaiter(this, void 0, void 0, function* () {
                     if (receipt.platform !== CdvPurchase.Platform.APPLE_APPSTORE)
                         return;
@@ -3418,7 +3440,8 @@ var CdvPurchase;
                             this.prepareReceipt(nativeData);
                         }
                     }
-                    if (!skReceipt.nativeData.appStoreReceipt) {
+                    // SK2 doesn't use monolithic receipts — skip the appStoreReceipt check
+                    if (!this.useSK2 && !skReceipt.nativeData.appStoreReceipt) {
                         this.log.info('Cannot prepare the receipt validation body, because appStoreReceipt is missing. Refreshing...');
                         const result = yield this.refreshReceipt();
                         if (!result || 'isError' in result) {
@@ -3431,16 +3454,35 @@ var CdvPurchase;
                         applicationReceipt = result;
                     }
                     const transaction = skReceipt.transactions.slice(-1)[0];
+                    const products = CdvPurchase.Utils.objectValues(this.validProducts).map(vp => new AppleAppStore.SKProduct(vp, vp, this.context.apiDecorators, { isEligible: () => true }));
+                    // SK2 uses a completely different transaction type ('apple-sk2') with JWS
+                    // SK1 uses 'ios-appstore' with the monolithic appStoreReceipt
+                    if (this.useSK2) {
+                        if (!(transaction === null || transaction === void 0 ? void 0 : transaction.jwsRepresentation)) {
+                            this.log.warn('SK2 mode but no JWS on transaction, skipping validation');
+                            return undefined;
+                        }
+                        return {
+                            id: applicationReceipt.bundleIdentifier,
+                            type: CdvPurchase.ProductType.APPLICATION,
+                            products,
+                            transaction: {
+                                type: 'apple-sk2',
+                                id: (_b = (_a = transaction === null || transaction === void 0 ? void 0 : transaction.products) === null || _a === void 0 ? void 0 : _a[0]) === null || _b === void 0 ? void 0 : _b.id,
+                                jwsRepresentation: transaction.jwsRepresentation,
+                            },
+                        };
+                    }
+                    const txBody = {
+                        type: 'ios-appstore',
+                        id: transaction === null || transaction === void 0 ? void 0 : transaction.transactionId,
+                        appStoreReceipt: applicationReceipt.appStoreReceipt,
+                    };
                     return {
                         id: applicationReceipt.bundleIdentifier,
                         type: CdvPurchase.ProductType.APPLICATION,
-                        // send all products and offers so validator get pricing information
-                        products: CdvPurchase.Utils.objectValues(this.validProducts).map(vp => new AppleAppStore.SKProduct(vp, vp, this.context.apiDecorators, { isEligible: () => true })),
-                        transaction: {
-                            type: 'ios-appstore',
-                            id: transaction === null || transaction === void 0 ? void 0 : transaction.transactionId,
-                            appStoreReceipt: applicationReceipt.appStoreReceipt,
-                        }
+                        products,
+                        transaction: txBody,
                     };
                 });
             }
@@ -3451,7 +3493,8 @@ var CdvPurchase;
                     let localReceiptUpdated = false;
                     if (response.ok) {
                         const vTransaction = (_a = response.data) === null || _a === void 0 ? void 0 : _a.transaction;
-                        if ((vTransaction === null || vTransaction === void 0 ? void 0 : vTransaction.type) === 'ios-appstore' && 'original_application_version' in vTransaction) {
+                        const isApple = (vTransaction === null || vTransaction === void 0 ? void 0 : vTransaction.type) === 'ios-appstore' || (vTransaction === null || vTransaction === void 0 ? void 0 : vTransaction.type) === 'apple-sk2';
+                        if (isApple && vTransaction && 'original_application_version' in vTransaction) {
                             (_b = this._receipt) === null || _b === void 0 ? void 0 : _b.transactions.forEach(t => {
                                 if (t.transactionId === AppleAppStore.APPLICATION_VIRTUAL_TRANSACTION_ID) {
                                     if (vTransaction.original_purchase_date_ms) {
@@ -3515,6 +3558,270 @@ var CdvPurchase;
         function appStoreError(code, message, productId) {
             return CdvPurchase.storeError(code, message, CdvPurchase.Platform.APPLE_APPSTORE, productId);
         }
+    })(AppleAppStore = CdvPurchase.AppleAppStore || (CdvPurchase.AppleAppStore = {}));
+})(CdvPurchase || (CdvPurchase = {}));
+var CdvPurchase;
+(function (CdvPurchase) {
+    let AppleAppStore;
+    (function (AppleAppStore) {
+        let SK2Bridge;
+        (function (SK2Bridge) {
+            const noop = (args) => { };
+            let log = noop;
+            function exec(methodName, options, success, error) {
+                window.cordova.exec(success, error, "StoreKit2Plugin", methodName, options);
+            }
+            function protectCall(callback, context, ...args) {
+                if (!callback)
+                    return;
+                try {
+                    callback.apply(this, args);
+                }
+                catch (err) {
+                    log('exception in ' + context + ': "' + err + '"');
+                }
+            }
+            class SK2NativeBridge {
+                constructor() {
+                    this.transactionsForProduct = {};
+                    this.initialized = false;
+                    this.registeredProducts = [];
+                    this.needRestoreNotification = false;
+                    this.pendingUpdates = [];
+                    /** True when this bridge is active (SK2 extension installed + iOS 15+) */
+                    this.isSK2 = true;
+                    window.storekit2 = this;
+                    this.options = {
+                        error: noop,
+                        ready: noop,
+                        purchased: noop,
+                        purchaseEnqueued: noop,
+                        purchasing: noop,
+                        purchaseFailed: noop,
+                        deferred: noop,
+                        finished: noop,
+                        restored: noop,
+                        receiptsRefreshed: noop,
+                        restoreFailed: noop,
+                        restoreCompleted: noop,
+                    };
+                }
+                /** Check if the SK2 extension plugin is installed */
+                static isAvailable() {
+                    // Check marker from the extension plugin
+                    const marker = window.CdvPurchaseStoreKit2;
+                    return !!(marker && marker.installed);
+                }
+                init(options, success, error) {
+                    this.options = {
+                        error: options.error || noop,
+                        ready: options.ready || noop,
+                        purchased: options.purchased || noop,
+                        purchaseEnqueued: options.purchaseEnqueued || noop,
+                        purchasing: options.purchasing || noop,
+                        purchaseFailed: options.purchaseFailed || noop,
+                        deferred: options.deferred || noop,
+                        finished: options.finished || noop,
+                        restored: options.restored || noop,
+                        receiptsRefreshed: options.receiptsRefreshed || noop,
+                        restoreFailed: options.restoreFailed || noop,
+                        restoreCompleted: options.restoreCompleted || noop,
+                    };
+                    if (options.debug) {
+                        exec('debug', [], noop, noop);
+                        log = options.log || function (msg) {
+                            console.log("[CdvPurchase.AppleAppStore.SK2Bridge] " + msg);
+                        };
+                    }
+                    if (options.autoFinish) {
+                        exec('autoFinish', [], noop, noop);
+                    }
+                    const setupOk = () => {
+                        log('setup ok');
+                        protectCall(this.options.ready, 'options.ready');
+                        protectCall(success, 'init.success');
+                        this.initialized = true;
+                        setTimeout(() => this.processPendingTransactions(), 50);
+                    };
+                    const setupFailed = (err) => {
+                        log('setup failed');
+                        protectCall(error, 'init.error', CdvPurchase.ErrorCode.SETUP, 'Setup failed: ' + err);
+                    };
+                    exec('setup', [], setupOk, setupFailed);
+                }
+                processPendingTransactions() {
+                    log('processing pending transactions');
+                    exec('processPendingTransactions', [], () => {
+                        this.finalizeTransactionUpdates();
+                    }, undefined);
+                }
+                purchase(productId, quantity, applicationUsername, discount, success, error) {
+                    quantity = (quantity | 0) || 1;
+                    const options = this.options;
+                    if (this.registeredProducts.indexOf(productId) < 0) {
+                        const msg = 'Purchasing ' + productId + ' failed. Ensure the product was loaded first with load()!';
+                        log(msg);
+                        if (typeof options.error === 'function') {
+                            protectCall(options.error, 'options.error', CdvPurchase.ErrorCode.PURCHASE, 'Trying to purchase an unknown product.', { productId, quantity });
+                        }
+                        return;
+                    }
+                    const purchaseOk = () => {
+                        log('Purchase enqueued ' + productId);
+                        if (typeof options.purchaseEnqueued === 'function') {
+                            protectCall(options.purchaseEnqueued, 'options.purchaseEnqueued', productId, quantity);
+                        }
+                        protectCall(success, 'purchase.success');
+                    };
+                    const purchaseFailed = () => {
+                        const errMsg = 'Purchase failed: ' + productId;
+                        log(errMsg);
+                        if (typeof options.error === 'function') {
+                            protectCall(options.error, 'options.error', CdvPurchase.ErrorCode.PURCHASE, errMsg, { productId, quantity });
+                        }
+                        protectCall(error, 'purchase.error');
+                    };
+                    exec('purchase', [productId, quantity, applicationUsername, discount || {}], purchaseOk, purchaseFailed);
+                }
+                canMakePayments(success, error) {
+                    return exec("canMakePayments", [], success, error);
+                }
+                restore(callback) {
+                    this.needRestoreNotification = true;
+                    exec('restoreCompletedTransactions', [], callback, callback);
+                }
+                manageSubscriptions(callback) {
+                    exec('manageSubscriptions', [], callback, callback);
+                }
+                manageBilling(callback) {
+                    exec('manageBilling', [], callback, callback);
+                }
+                presentCodeRedemptionSheet(callback) {
+                    exec('presentCodeRedemptionSheet', [], callback, callback);
+                }
+                load(productIds, success, error) {
+                    const options = this.options;
+                    if (!productIds || !productIds.length) {
+                        protectCall(success, 'load.success', [], []);
+                        return;
+                    }
+                    log('load ' + JSON.stringify(productIds));
+                    const loadOk = (array) => {
+                        const valid = array[0];
+                        const invalid = array[1];
+                        log('load ok: { valid:' + JSON.stringify(valid) + ' invalid:' + JSON.stringify(invalid) + ' }');
+                        protectCall(success, 'load.success', valid, invalid);
+                    };
+                    const loadFailed = (errMessage) => {
+                        log('load failed: ' + errMessage);
+                        protectCall(options.error, 'options.error', CdvPurchase.ErrorCode.LOAD, 'Load failed: ' + errMessage);
+                        protectCall(error, 'load.error', CdvPurchase.ErrorCode.LOAD, 'Load failed: ' + errMessage);
+                    };
+                    this.registeredProducts = this.registeredProducts.concat(productIds);
+                    exec('load', [productIds], loadOk, loadFailed);
+                }
+                finish(transactionId, success, error) {
+                    exec('finishTransaction', [transactionId], success, error);
+                }
+                finalizeTransactionUpdates() {
+                    for (let i = 0; i < this.pendingUpdates.length; ++i) {
+                        const args = this.pendingUpdates[i];
+                        this.transactionUpdated(args.state, args.errorCode, args.errorText, args.transactionIdentifier, args.productId, args.transactionReceipt, args.originalTransactionIdentifier, args.transactionDate, args.discountId, args.expirationDate, args.jwsRepresentation);
+                    }
+                    this.pendingUpdates = [];
+                }
+                lastTransactionUpdated() {
+                    // no more pending transactions
+                }
+                /** Called from native. Same as SK1 but with extra SK2 fields. */
+                transactionUpdated(state, errorCode, errorText, transactionIdentifier, productId, transactionReceipt, originalTransactionIdentifier, transactionDate, discountId, expirationDate, jwsRepresentation) {
+                    if (!this.initialized) {
+                        this.pendingUpdates.push({
+                            state, errorCode, errorText, transactionIdentifier,
+                            productId, transactionReceipt, originalTransactionIdentifier,
+                            transactionDate, discountId, expirationDate, jwsRepresentation
+                        });
+                        return;
+                    }
+                    log("transaction updated:" + transactionIdentifier +
+                        " state:" + state + " product:" + productId);
+                    if (productId && transactionIdentifier) {
+                        if (this.transactionsForProduct[productId]) {
+                            this.transactionsForProduct[productId].push(transactionIdentifier);
+                        }
+                        else {
+                            this.transactionsForProduct[productId] = [transactionIdentifier];
+                        }
+                    }
+                    switch (state) {
+                        case "PaymentTransactionStatePurchasing":
+                            protectCall(this.options.purchasing, 'options.purchasing', productId);
+                            return;
+                        case "PaymentTransactionStatePurchased":
+                            protectCall(this.options.purchased, 'options.purchased', transactionIdentifier, productId, originalTransactionIdentifier, transactionDate, discountId, expirationDate, jwsRepresentation);
+                            return;
+                        case "PaymentTransactionStateDeferred":
+                            protectCall(this.options.deferred, 'options.deferred', productId);
+                            return;
+                        case "PaymentTransactionStateFailed":
+                            protectCall(this.options.purchaseFailed, 'options.purchaseFailed', productId, errorCode || CdvPurchase.ErrorCode.UNKNOWN, errorText || 'ERROR');
+                            protectCall(this.options.error, 'options.error', errorCode || CdvPurchase.ErrorCode.UNKNOWN, errorText || 'ERROR', { productId });
+                            return;
+                        case "PaymentTransactionStateRestored":
+                            protectCall(this.options.restored, 'options.restored', transactionIdentifier, productId, originalTransactionIdentifier, transactionDate, discountId, expirationDate, jwsRepresentation);
+                            return;
+                        case "PaymentTransactionStateFinished":
+                            protectCall(this.options.finished, 'options.finished', transactionIdentifier, productId);
+                            return;
+                    }
+                }
+                restoreCompletedTransactionsFinished() {
+                    if (!this.needRestoreNotification)
+                        return;
+                    this.needRestoreNotification = false;
+                    protectCall(this.options.restoreCompleted, 'options.restoreCompleted');
+                }
+                restoreCompletedTransactionsFailed(errorCode) {
+                    if (!this.needRestoreNotification)
+                        return;
+                    this.needRestoreNotification = false;
+                    protectCall(this.options.restoreFailed, 'options.restoreFailed', errorCode);
+                }
+                parseReceiptArgs(args) {
+                    return {
+                        appStoreReceipt: args[0],
+                        bundleIdentifier: args[1],
+                        bundleShortVersion: args[2],
+                        bundleNumericVersion: args[3],
+                        bundleSignature: args[4],
+                    };
+                }
+                refreshReceipts(successCb, errorCb) {
+                    const loaded = (args) => {
+                        const data = this.parseReceiptArgs(args);
+                        this.appStoreReceipt = data;
+                        protectCall(this.options.receiptsRefreshed, 'options.receiptsRefreshed', data);
+                        protectCall(successCb, "refreshReceipts.success", data);
+                    };
+                    const error = (errMessage) => {
+                        log('refresh receipt failed: ' + errMessage);
+                        protectCall(errorCb, "refreshReceipts.error", CdvPurchase.ErrorCode.REFRESH_RECEIPTS, 'Failed to refresh receipt: ' + errMessage);
+                    };
+                    this.appStoreReceipt = null;
+                    exec('appStoreRefreshReceipt', [], loaded, error);
+                }
+                loadReceipts(callback, errorCb) {
+                    const loaded = (args) => {
+                        const data = this.parseReceiptArgs(args);
+                        this.appStoreReceipt = data;
+                        protectCall(callback, 'loadReceipts.callback', data);
+                    };
+                    log('loading appStoreReceipt (SK2)');
+                    exec('appStoreReceipt', [], loaded, undefined);
+                }
+            }
+            SK2Bridge.SK2NativeBridge = SK2NativeBridge;
+        })(SK2Bridge = AppleAppStore.SK2Bridge || (AppleAppStore.SK2Bridge = {}));
     })(AppleAppStore = CdvPurchase.AppleAppStore || (CdvPurchase.AppleAppStore = {}));
 })(CdvPurchase || (CdvPurchase = {}));
 var CdvPurchase;
@@ -4086,13 +4393,17 @@ var CdvPurchase;
         AppleAppStore.SKApplicationReceipt = SKApplicationReceipt;
         /** StoreKit transaction */
         class SKTransaction extends CdvPurchase.Transaction {
-            refresh(productId, originalTransactionIdentifier, transactionDate, discountId) {
+            refresh(productId, originalTransactionIdentifier, transactionDate, discountId, expirationDateMs, jwsRepresentation) {
                 if (productId)
                     this.products = [{ id: productId, offerId: discountId }];
                 if (originalTransactionIdentifier)
                     this.originalTransactionId = originalTransactionIdentifier;
                 if (transactionDate)
                     this.purchaseDate = new Date(+transactionDate);
+                if (expirationDateMs)
+                    this.expirationDate = new Date(+expirationDateMs);
+                if (jwsRepresentation)
+                    this.jwsRepresentation = jwsRepresentation;
             }
         }
         AppleAppStore.SKTransaction = SKTransaction;


### PR DESCRIPTION
## Summary

- Add StoreKit 2 support as an optional extension plugin (`cordova-plugin-purchase-storekit2`)
- When the extension is installed, the Apple AppStore adapter automatically upgrades from StoreKit 1 to StoreKit 2 on iOS 15+ — no changes to the public API
- Follows the same extension pattern as the Braintree plugin

**Main plugin changes:**
- Extract shared `BridgeInterface` for SK1/SK2 bridge compatibility
- Add SK2 TypeScript bridge communicating with `StoreKit2Plugin` native feature
- Add `jwsRepresentation` field to `SKTransaction` and `ApiValidatorBodyTransactionAppleSK2` type for iaptic validation (`type: 'apple-sk2'`)
- Adapter detects SK2 extension at runtime, creates the appropriate bridge, handles empty `appStoreReceipt` gracefully in SK2 mode

**Extension plugin** (separate repo: `cordova-plugin-purchase-storekit2`):
- Swift native `StoreKit2Plugin` — product loading, purchases, transaction observer, JWS extraction, restore, subscription management
- Requires cordova-ios 7+ (tested with cordova-ios 8)

## Test plan

- [ ] `make all` passes (unit tests + type check)
- [ ] iOS build CI passes
- [ ] Without extension installed: existing SK1 behavior unchanged
- [ ] With extension installed on iOS 15+: adapter logs "StoreKit 2 extension detected", uses SK2 bridge
- [ ] Purchases produce `apple-sk2` validation requests with `jwsRepresentation`
- [ ] Restore sends JWS and expiration data through to transaction