### PR TITLE
ci: fix iOS build failure on macos-15 (iOS 18.2 platform not installed)

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -51,7 +51,8 @@ jobs:
           xcodebuild build
           -workspace App.xcworkspace
           -scheme App
-          -sdk iphoneos
+          -sdk iphonesimulator
+          -destination 'generic/platform=iOS Simulator'
           CODE_SIGN_IDENTITY=""
           CODE_SIGNING_REQUIRED=NO
           CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## Summary

- The `macos-15` + Xcode 16.2 matrix entry in the iOS Build workflow has been failing since 2026-03-25 with `error: iOS 18.2 Platform Not Installed` (exit code 65)
- Root cause: GitHub Actions `macos-15` runners don't ship the iOS device SDK platform pre-installed for Xcode 16.2 — this is a CI infrastructure limitation, not a plugin issue
- Fix: switch `xcodebuild` from `-sdk iphoneos` to `-sdk iphonesimulator -destination 'generic/platform=iOS Simulator'`; for a compilation check this is equivalent and doesn't require the device platform

## Test plan

- [ ] Confirm `Xcode 16.2 (macos-15)` job passes in this PR's CI run
- [ ] Confirm `Xcode 15.4 (macos-14)` job still passes (unchanged)