### PR TITLE
Add store.getStorefront() for billing country code

### DIFF
--- a/capacitor/android/src/main/java/cc/fovea/iap/PurchasePlugin.java
+++ b/capacitor/android/src/main/java/cc/fovea/iap/PurchasePlugin.java
@@ -24,9 +24,12 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode;
 import com.android.billingclient.api.BillingClient.FeatureType;
 import com.android.billingclient.api.BillingClient.ProductType;
 import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingConfig;
+import com.android.billingclient.api.BillingConfigResponseListener;
 import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingFlowParams.ProductDetailsParams;
 import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.GetBillingConfigParams;
 import com.android.billingclient.api.ConsumeParams;
 import com.android.billingclient.api.ConsumeResponseListener;
 import com.android.billingclient.api.PendingPurchasesParams;
@@ -724,6 +727,35 @@ public class PurchasePlugin extends Plugin implements
                 Uri.parse("http://play.google.com/store/account/subscriptions"));
         getActivity().startActivity(browserIntent);
         call.resolve();
+    }
+
+    /**
+     * Retrieve the user's Play Store billing country code (ISO 3166-1 alpha-2).
+     */
+    @PluginMethod
+    public void getStorefront(final PluginCall call) {
+        Log.d(TAG, "getStorefront()");
+        executeServiceRequest(() -> {
+            GetBillingConfigParams params = GetBillingConfigParams.newBuilder().build();
+            mBillingClient.getBillingConfigAsync(params, new BillingConfigResponseListener() {
+                @Override
+                public void onBillingConfigResponse(
+                        BillingResult billingResult,
+                        BillingConfig billingConfig) {
+                    if (billingResult.getResponseCode() == BillingResponseCode.OK
+                            && billingConfig != null) {
+                        String countryCode = billingConfig.getCountryCode();
+                        Log.d(TAG, "getStorefront() -> " + countryCode);
+                        JSObject ret = new JSObject();
+                        ret.put("countryCode", countryCode);
+                        call.resolve(ret);
+                    } else {
+                        Log.d(TAG, "getStorefront() -> Failed: " + format(billingResult));
+                        call.reject("Failed to get billing config: " + format(billingResult));
+                    }
+                }
+            });
+        });
     }
 
     // -------------------------------------------------------------------------

--- a/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
+++ b/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
@@ -26,6 +26,7 @@ public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "presentCodeRedemptionSheet", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "refreshReceipts", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "loadReceipts", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStorefront", returnType: CAPPluginReturnPromise),
     ]
 
     private var _sk2State: AnyObject?
@@ -311,6 +312,18 @@ public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func loadReceipts(_ call: CAPPluginCall) {
         // Same as refreshReceipts for SK2
         refreshReceipts(call)
+    }
+
+    @objc func getStorefront(_ call: CAPPluginCall) {
+        // SKPaymentQueue.storefront is a StoreKit 1 API available from iOS 13,
+        // which matches the plugin's minimum deployment target.
+        if let storefront = SKPaymentQueue.default().storefront {
+            debugLog("getStorefront: \(storefront.countryCode)")
+            call.resolve(["countryCode": storefront.countryCode])
+        } else {
+            debugLog("getStorefront: storefront not available")
+            call.reject("Storefront not available")
+        }
     }
 
     // MARK: - Helpers

--- a/capacitor/src/definitions.ts
+++ b/capacitor/src/definitions.ts
@@ -39,6 +39,15 @@ export interface PurchasePluginPlugin {
   /** Open billing management UI */
   manageBilling(): Promise<void>;
 
+  /**
+   * Retrieve the user's storefront country code.
+   *
+   * iOS returns an ISO 3166-1 alpha-3 code (e.g., "USA"); Android returns
+   * an alpha-2 code (e.g., "US"). The TypeScript adapter normalizes iOS
+   * responses to alpha-2.
+   */
+  getStorefront(): Promise<{ countryCode: string }>;
+
   // ===== Android-specific =====
 
   /** Consume a purchase (Android) */

--- a/src/android/cc/fovea/PurchasePlugin.java
+++ b/src/android/cc/fovea/PurchasePlugin.java
@@ -263,6 +263,9 @@ public final class PurchasePlugin
         Intent browserIntent = new Intent(Intent.ACTION_VIEW,
             Uri.parse("http://play.google.com/store/account/subscriptions"));
         cordova.getActivity().startActivity(browserIntent);
+      } else if ("getStorefront".equals(action)) {
+        getStorefront(callbackContext);
+        return true;
       } else {
         // No handler for the action
         isValidAction = false;
@@ -275,6 +278,38 @@ public final class PurchasePlugin
 
     // Method not found
     return isValidAction;
+  }
+
+  /**
+   * Retrieves the user's Play Store billing country code.
+   *
+   * Uses BillingClient.getBillingConfigAsync() to obtain the country
+   * code as ISO 3166-1 alpha-2 (e.g., "US", "FR").
+   */
+  private void getStorefront(final CallbackContext callbackContext) {
+    Log.d(mTag, "getStorefront()");
+    executeServiceRequest(() -> {
+      com.android.billingclient.api.GetBillingConfigParams params =
+          com.android.billingclient.api.GetBillingConfigParams.newBuilder().build();
+      mBillingClient.getBillingConfigAsync(params,
+          new com.android.billingclient.api.BillingConfigResponseListener() {
+            @Override
+            public void onBillingConfigResponse(
+                BillingResult billingResult,
+                com.android.billingclient.api.BillingConfig billingConfig) {
+              if (billingResult.getResponseCode() == BillingResponseCode.OK
+                  && billingConfig != null) {
+                String countryCode = billingConfig.getCountryCode();
+                Log.d(mTag, "getStorefront() -> " + countryCode);
+                callbackContext.success(countryCode);
+              } else {
+                Log.d(mTag, "getStorefront() -> Failed: " + format(billingResult));
+                callbackContext.error("Failed to get billing config: "
+                    + format(billingResult));
+              }
+            }
+          });
+    });
   }
 
   private String getPublicKey() {

--- a/src/ios/InAppPurchase.h
+++ b/src/ios/InAppPurchase.h
@@ -44,6 +44,7 @@
 - (void) debug: (CDVInvokedUrlCommand*)command;
 - (void) autoFinish: (CDVInvokedUrlCommand*)command;
 - (void) finishTransaction: (CDVInvokedUrlCommand*)command;
+- (void) getStorefront: (CDVInvokedUrlCommand*)command;
 
 - (void) onReset;
 - (void) processPendingTransactionUpdates;

--- a/src/ios/InAppPurchase.m
+++ b/src/ios/InAppPurchase.m
@@ -274,6 +274,27 @@ static NSString *toTimestamp(NSDate *date) {
     g_autoFinishEnabled = YES;
 }
 
+-(void) getStorefront: (CDVInvokedUrlCommand*)command {
+    DLog(@"getStorefront");
+    if (@available(iOS 13.0, macOS 10.15, *)) {
+        SKStorefront *storefront = [[SKPaymentQueue defaultQueue] storefront];
+        if (storefront) {
+            NSString *countryCode = storefront.countryCode;
+            DLog(@"getStorefront: %@", countryCode);
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:countryCode];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        } else {
+            DLog(@"getStorefront: storefront not available");
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Storefront not available"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+    } else {
+        DLog(@"getStorefront: not available (requires iOS 13.0+)");
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Storefront requires iOS 13.0+"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }
+}
+
 -(void) setup: (CDVInvokedUrlCommand*)command {
     CDVPluginResult* pluginResult = nil;
     g_initialized = YES;

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -830,6 +830,79 @@ namespace CdvPurchase {
                     this.bridge.presentCodeRedemptionSheet(resolve);
                 });
             }
+
+            async getStorefront(): Promise<string | undefined> {
+                if (!this.bridge.getStorefront) return undefined;
+                const countryCode = await this.bridge.getStorefront();
+                if (!countryCode) return undefined;
+                // SKStorefront.countryCode returns ISO 3166-1 alpha-3 (e.g., "USA"),
+                // convert to alpha-2 (e.g., "US") for consistency with Google Play.
+                return isoAlpha3ToAlpha2(countryCode) || countryCode;
+            }
+        }
+
+        /**
+         * Convert ISO 3166-1 alpha-3 country code to alpha-2.
+         *
+         * Apple's SKStorefront.countryCode returns alpha-3 codes (e.g., "USA").
+         * This function converts them to the more common alpha-2 format (e.g., "US")
+         * for consistency with Google Play which already returns alpha-2.
+         */
+        const ISO_ALPHA3_TO_ALPHA2: { [key: string]: string } = {
+            AFG: 'AF', ALB: 'AL', DZA: 'DZ', ASM: 'AS', AND: 'AD',
+            AGO: 'AO', AIA: 'AI', ATA: 'AQ', ATG: 'AG', ARG: 'AR',
+            ARM: 'AM', ABW: 'AW', AUS: 'AU', AUT: 'AT', AZE: 'AZ',
+            BHS: 'BS', BHR: 'BH', BGD: 'BD', BRB: 'BB', BLR: 'BY',
+            BEL: 'BE', BLZ: 'BZ', BEN: 'BJ', BMU: 'BM', BTN: 'BT',
+            BOL: 'BO', BES: 'BQ', BIH: 'BA', BWA: 'BW', BVT: 'BV',
+            BRA: 'BR', IOT: 'IO', BRN: 'BN', BGR: 'BG', BFA: 'BF',
+            BDI: 'BI', CPV: 'CV', KHM: 'KH', CMR: 'CM', CAN: 'CA',
+            CYM: 'KY', CAF: 'CF', TCD: 'TD', CHL: 'CL', CHN: 'CN',
+            CXR: 'CX', CCK: 'CC', COL: 'CO', COM: 'KM', COG: 'CG',
+            COD: 'CD', COK: 'CK', CRI: 'CR', CIV: 'CI', HRV: 'HR',
+            CUB: 'CU', CUW: 'CW', CYP: 'CY', CZE: 'CZ', DNK: 'DK',
+            DJI: 'DJ', DMA: 'DM', DOM: 'DO', ECU: 'EC', EGY: 'EG',
+            SLV: 'SV', GNQ: 'GQ', ERI: 'ER', EST: 'EE', SWZ: 'SZ',
+            ETH: 'ET', FLK: 'FK', FRO: 'FO', FJI: 'FJ', FIN: 'FI',
+            FRA: 'FR', GUF: 'GF', PYF: 'PF', ATF: 'TF', GAB: 'GA',
+            GMB: 'GM', GEO: 'GE', DEU: 'DE', GHA: 'GH', GIB: 'GI',
+            GRC: 'GR', GRL: 'GL', GRD: 'GD', GLP: 'GP', GUM: 'GU',
+            GTM: 'GT', GGY: 'GG', GIN: 'GN', GNB: 'GW', GUY: 'GY',
+            HTI: 'HT', HMD: 'HM', VAT: 'VA', HND: 'HN', HKG: 'HK',
+            HUN: 'HU', ISL: 'IS', IND: 'IN', IDN: 'ID', IRN: 'IR',
+            IRQ: 'IQ', IRL: 'IE', IMN: 'IM', ISR: 'IL', ITA: 'IT',
+            JAM: 'JM', JPN: 'JP', JEY: 'JE', JOR: 'JO', KAZ: 'KZ',
+            KEN: 'KE', KIR: 'KI', PRK: 'KP', KOR: 'KR', KWT: 'KW',
+            KGZ: 'KG', LAO: 'LA', LVA: 'LV', LBN: 'LB', LSO: 'LS',
+            LBR: 'LR', LBY: 'LY', LIE: 'LI', LTU: 'LT', LUX: 'LU',
+            MAC: 'MO', MDG: 'MG', MWI: 'MW', MYS: 'MY', MDV: 'MV',
+            MLI: 'ML', MLT: 'MT', MHL: 'MH', MTQ: 'MQ', MRT: 'MR',
+            MUS: 'MU', MYT: 'YT', MEX: 'MX', FSM: 'FM', MDA: 'MD',
+            MCO: 'MC', MNG: 'MN', MNE: 'ME', MSR: 'MS', MAR: 'MA',
+            MOZ: 'MZ', MMR: 'MM', NAM: 'NA', NRU: 'NR', NPL: 'NP',
+            NLD: 'NL', NCL: 'NC', NZL: 'NZ', NIC: 'NI', NER: 'NE',
+            NGA: 'NG', NIU: 'NU', NFK: 'NF', MKD: 'MK', MNP: 'MP',
+            NOR: 'NO', OMN: 'OM', PAK: 'PK', PLW: 'PW', PSE: 'PS',
+            PAN: 'PA', PNG: 'PG', PRY: 'PY', PER: 'PE', PHL: 'PH',
+            PCN: 'PN', POL: 'PL', PRT: 'PT', PRI: 'PR', QAT: 'QA',
+            REU: 'RE', ROU: 'RO', RUS: 'RU', RWA: 'RW', BLM: 'BL',
+            SHN: 'SH', KNA: 'KN', LCA: 'LC', MAF: 'MF', SPM: 'PM',
+            VCT: 'VC', WSM: 'WS', SMR: 'SM', STP: 'ST', SAU: 'SA',
+            SEN: 'SN', SRB: 'RS', SYC: 'SC', SLE: 'SL', SGP: 'SG',
+            SXM: 'SX', SVK: 'SK', SVN: 'SI', SLB: 'SB', SOM: 'SO',
+            ZAF: 'ZA', SGS: 'GS', SSD: 'SS', ESP: 'ES', LKA: 'LK',
+            SDN: 'SD', SUR: 'SR', SJM: 'SJ', SWE: 'SE', CHE: 'CH',
+            SYR: 'SY', TWN: 'TW', TJK: 'TJ', TZA: 'TZ', THA: 'TH',
+            TLS: 'TL', TGO: 'TG', TKL: 'TK', TON: 'TO', TTO: 'TT',
+            TUN: 'TN', TUR: 'TR', TKM: 'TM', TCA: 'TC', TUV: 'TV',
+            UGA: 'UG', UKR: 'UA', ARE: 'AE', GBR: 'GB', USA: 'US',
+            UMI: 'UM', URY: 'UY', UZB: 'UZ', VUT: 'VU', VEN: 'VE',
+            VNM: 'VN', VGB: 'VG', VIR: 'VI', WLF: 'WF', ESH: 'EH',
+            YEM: 'YE', ZMB: 'ZM', ZWE: 'ZW',
+        };
+
+        function isoAlpha3ToAlpha2(alpha3: string): string | undefined {
+            return ISO_ALPHA3_TO_ALPHA2[alpha3.toUpperCase()];
         }
 
         function appStoreError(code: ErrorCode, message: string, productId: string | null) {

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -805,7 +805,7 @@ namespace CdvPurchase {
             checkSupport(functionality: PlatformFunctionality): boolean {
                 if (functionality === 'order') return this._canMakePayments;
                 const supported: PlatformFunctionality[] = [
-                    'order', 'manageBilling', 'manageSubscriptions'
+                    'order', 'manageBilling', 'manageSubscriptions', 'getStorefront'
                 ];
                 return supported.indexOf(functionality) >= 0;
             }
@@ -835,8 +835,9 @@ namespace CdvPurchase {
                 if (!this.bridge.getStorefront) return undefined;
                 const countryCode = await this.bridge.getStorefront();
                 if (!countryCode) return undefined;
-                // SKStorefront.countryCode returns ISO 3166-1 alpha-3 (e.g., "USA"),
-                // convert to alpha-2 (e.g., "US") for consistency with Google Play.
+                // SKStorefront.countryCode typically returns ISO 3166-1 alpha-3 (e.g., "USA").
+                // The fallback `|| countryCode` handles cases where Apple returns alpha-2 directly
+                // or uses a non-standard code (e.g., territories not in ISO 3166-1).
                 return isoAlpha3ToAlpha2(countryCode) || countryCode;
             }
         }

--- a/src/ts/platforms/apple-appstore/appstore-bridge-capacitor.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-capacitor.ts
@@ -312,6 +312,24 @@ namespace CdvPurchase {
                         this.options.restoreFailed(errorCode);
                     }
                 }
+
+                /** Retrieve the storefront country code from StoreKit */
+                getStorefront(): Promise<string | undefined> {
+                    return new Promise((resolve) => {
+                        const plugin = this.plugin;
+                        if (!plugin) {
+                            log('getStorefront failed: plugin not available');
+                            resolve(undefined);
+                            return;
+                        }
+                        plugin.getStorefront()
+                            .then((result: { countryCode: string }) => resolve(result.countryCode || undefined))
+                            .catch((err: any) => {
+                                log('getStorefront failed: ' + (err?.message || err));
+                                resolve(undefined);
+                            });
+                    });
+                }
             }
         }
     }

--- a/src/ts/platforms/apple-appstore/appstore-bridge-interface.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-interface.ts
@@ -42,6 +42,8 @@ namespace CdvPurchase {
                                 errorCb: (code: ErrorCode, message: string) => void): void;
                 loadReceipts(callback: (receipt: ApplicationReceipt) => void,
                              errorCb: (code: ErrorCode, message: string) => void): void;
+                /** Retrieve the storefront country code (alpha-3 on iOS) */
+                getStorefront?(): Promise<string | undefined>;
             }
         }
     }

--- a/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
@@ -348,6 +348,18 @@ namespace CdvPurchase {
                     exec('appStoreRefreshReceipt', [], loaded, error);
                 }
 
+                /** Retrieve the storefront country code from StoreKit */
+                getStorefront(): Promise<string | undefined> {
+                    return new Promise((resolve) => {
+                        // SK2 uses the same native getStorefront action via InAppPurchase plugin
+                        window.cordova.exec((countryCode: string) => {
+                            resolve(countryCode || undefined);
+                        }, () => {
+                            resolve(undefined);
+                        }, "InAppPurchase", "getStorefront", []);
+                    });
+                }
+
                 loadReceipts(callback: (receipt: ApplicationReceipt) => void,
                              errorCb: (code: ErrorCode, message: string) => void) {
                     const loaded = (args: [string, string, string, number, string]) => {

--- a/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
@@ -354,7 +354,8 @@ namespace CdvPurchase {
                         // SK2 uses the same native getStorefront action via InAppPurchase plugin
                         window.cordova.exec((countryCode: string) => {
                             resolve(countryCode || undefined);
-                        }, () => {
+                        }, (err: string) => {
+                            log('getStorefront failed: ' + err);
                             resolve(undefined);
                         }, "InAppPurchase", "getStorefront", []);
                     });

--- a/src/ts/platforms/apple-appstore/appstore-bridge.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge.ts
@@ -622,7 +622,8 @@ namespace CdvPurchase {
                     return new Promise((resolve) => {
                         exec('getStorefront', [], (countryCode: string) => {
                             resolve(countryCode || undefined);
-                        }, () => {
+                        }, (err: string) => {
+                            log('getStorefront failed: ' + err);
                             resolve(undefined);
                         });
                     });

--- a/src/ts/platforms/apple-appstore/appstore-bridge.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge.ts
@@ -617,6 +617,17 @@ namespace CdvPurchase {
                     exec('appStoreRefreshReceipt', [], loaded, error);
                 }
 
+                /** Retrieve the storefront country code from StoreKit */
+                getStorefront(): Promise<string | undefined> {
+                    return new Promise((resolve) => {
+                        exec('getStorefront', [], (countryCode: string) => {
+                            resolve(countryCode || undefined);
+                        }, () => {
+                            resolve(undefined);
+                        });
+                    });
+                }
+
                 loadReceipts(callback: (receipt: ApplicationReceipt) => void, errorCb: (code: ErrorCode, message: string) => void) {
 
                     const loaded = (args: RawReceiptArgs) => {

--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -601,7 +601,7 @@ namespace CdvPurchase {
 
             checkSupport(functionality: PlatformFunctionality): boolean {
                 const supported: PlatformFunctionality[] = [
-                    'order', 'manageBilling', 'manageSubscriptions'
+                    'order', 'manageBilling', 'manageSubscriptions', 'getStorefront'
                 ];
                 return supported.indexOf(functionality) >= 0;
             }

--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -588,6 +588,17 @@ namespace CdvPurchase {
                 return;
             }
 
+            async getStorefront(): Promise<string | undefined> {
+                return new Promise((resolve) => {
+                    this.bridge.getStorefront((countryCode: string) => {
+                        resolve(countryCode || undefined);
+                    }, (message: string) => {
+                        this.log.warn('getStorefront failed: ' + message);
+                        resolve(undefined);
+                    });
+                });
+            }
+
             checkSupport(functionality: PlatformFunctionality): boolean {
                 const supported: PlatformFunctionality[] = [
                     'order', 'manageBilling', 'manageSubscriptions'

--- a/src/ts/platforms/google-play/googleplay-bridge-capacitor.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge-capacitor.ts
@@ -167,6 +167,15 @@ namespace CdvPurchase {
                 launchPriceChangeConfirmationFlow(productId: string) {
                     this.plugin.launchPriceChangeConfirmationFlow({ productId });
                 }
+
+                getStorefront(success: (countryCode: string) => void, fail: ErrorCallback) {
+                    if (this.options.showLog) {
+                        log('getStorefront()');
+                    }
+                    this.plugin.getStorefront()
+                        .then((result: { countryCode: string }) => success(result.countryCode))
+                        .catch((err: any) => fail(err?.message || 'getStorefront failed', err?.code));
+                }
             }
 
             function ensureObject<T extends Object>(obj: any): T {

--- a/src/ts/platforms/google-play/googleplay-bridge-interface.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge-interface.ts
@@ -39,6 +39,8 @@ namespace CdvPurchase {
                 manageBilling(): void;
 
                 launchPriceChangeConfirmationFlow(productId: string): void;
+
+                getStorefront(success: (countryCode: string) => void, fail: ErrorCallback): void;
             }
         }
     }

--- a/src/ts/platforms/google-play/googleplay-bridge.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge.ts
@@ -325,6 +325,13 @@ namespace CdvPurchase {
                     return window.cordova.exec(function () { }, function () { }, "InAppBillingPlugin", "manageBilling", []);
                 }
 
+                getStorefront(success: (countryCode: string) => void, fail: ErrorCallback) {
+                    if (this.options.showLog) {
+                        log('getStorefront()');
+                    }
+                    return window.cordova.exec(success, errorCb(fail), "InAppBillingPlugin", "getStorefront", []);
+                }
+
                 launchPriceChangeConfirmationFlow(productId: string) {
                     return window.cordova.exec(function () { }, function () { }, "InAppBillingPlugin", "launchPriceChangeConfirmationFlow", [productId]);
                 }

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -771,6 +771,24 @@ namespace CdvPurchase {
         }
 
         /**
+         * Retrieve the billing country code from the platform's storefront.
+         *
+         * Returns an ISO 3166-1 alpha-2 country code (e.g., "US", "FR"),
+         * or undefined if the storefront information is not available.
+         *
+         * @param platform - The platform to get the storefront from. If not specified, uses the first ready adapter.
+         *
+         * @example
+         * const country = await store.getStorefront();
+         * console.log('Billing country: ' + country); // e.g., "US"
+         */
+        async getStorefront(platform?: Platform): Promise<string | undefined> {
+            const adapter = this.adapters.findReady(platform);
+            if (!adapter?.getStorefront) return undefined;
+            return adapter.getStorefront();
+        }
+
+        /**
          * The default payment platform to use depending on the OS.
          *
          * - on iOS: `APPLE_APPSTORE`

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -776,6 +776,14 @@ namespace CdvPurchase {
          * Returns an ISO 3166-1 alpha-2 country code (e.g., "US", "FR"),
          * or undefined if the storefront information is not available.
          *
+         * Returns `undefined` if called before `store.initialize()` completes,
+         * or if the platform does not support storefront queries.
+         *
+         * On iOS, requires iOS 13 or later.
+         *
+         * Note: may return a non-standard code for regions not covered by ISO 3166-1
+         * (the raw platform code is returned as fallback).
+         *
          * @param platform - The platform to get the storefront from. If not specified, uses the first ready adapter.
          *
          * @example

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -212,6 +212,14 @@ namespace CdvPurchase {
          * Might ask the user to login.
          */
         restorePurchases(): Promise<IError | undefined>;
+
+        /**
+         * Retrieve the billing country code from the platform's storefront.
+         *
+         * Returns an ISO 3166-1 alpha-2 country code (e.g., "US", "FR"),
+         * or undefined if the storefront information is not available.
+         */
+        getStorefront?(): Promise<string | undefined>;
     }
 
 

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -276,7 +276,7 @@ namespace CdvPurchase {
      *
      * @see {@link Store.checkSupport}
      */
-    export type PlatformFunctionality = 'requestPayment' | 'order' | 'manageSubscriptions' | 'manageBilling';
+    export type PlatformFunctionality = 'requestPayment' | 'order' | 'manageSubscriptions' | 'manageBilling' | 'getStorefront';
 
     /**
      * Possible states of a transaction.


### PR DESCRIPTION
## Summary
- Add `store.getStorefront(platform?)` method returning the user's billing country as ISO 3166-1 alpha-2 (e.g., "US", "FR")
- iOS: reads `SKStorefront.countryCode` (alpha-3) and converts to alpha-2 via lookup table (requires iOS 13+)
- Android: calls `BillingClient.getBillingConfigAsync()` which returns alpha-2 natively
- Both SK1 and SK2 bridges supported

Fixes #1666.

## Test plan
- [x] TypeScript compiles cleanly
- [x] Unit tests pass
- [ ] Manual test: iOS — verify `store.getStorefront()` returns correct 2-letter country code
- [ ] Manual test: Android — verify `store.getStorefront()` returns correct 2-letter country code
- [ ] Verify behavior when called before `store.initialize()` (should return `undefined`)
- [ ] Verify SK2 extension compatibility (separate repo)