### PR TITLE
feat: add first-class Capacitor 6+ plugin support

### DIFF
--- a/.github/workflows/build-capacitor-android.yml
+++ b/.github/workflows/build-capacitor-android.yml
@@ -1,0 +1,61 @@
+name: Capacitor Android Build
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Accept Android SDK licenses
+        run: yes | sdkmanager --licenses > /dev/null 2>&1 || true
+
+      - name: Install dependencies and build TypeScript
+        run: |
+          npm ci
+          npx tsc
+
+      - name: Install Capacitor CLI and create test app
+        run: |
+          npm install -g @capacitor/cli
+          npx @capacitor/create-app test-cap-app --name TestApp --app-id com.test.app
+          cd test-cap-app
+          npm install @capacitor/android
+          npx cap add android
+
+      - name: Install plugin
+        run: |
+          cd test-cap-app
+          # Create minimal web assets (required by cap sync)
+          mkdir -p dist
+          echo '<html><body></body></html>' > dist/index.html
+          # Remove default plugins to avoid version conflicts
+          npm uninstall @capacitor/camera @capacitor/splash-screen 2>/dev/null || true
+          # Copy compiled store.js into capacitor package
+          cp "$GITHUB_WORKSPACE/www/store.js" "$GITHUB_WORKSPACE/capacitor/www/store.js"
+          cp "$GITHUB_WORKSPACE/www/store.d.ts" "$GITHUB_WORKSPACE/capacitor/www/store.d.ts"
+          npm install "$GITHUB_WORKSPACE/capacitor"
+          npx cap sync android
+
+      - name: Build Android
+        run: |
+          cd test-cap-app/android
+          ./gradlew assembleDebug

--- a/.github/workflows/build-capacitor-ios.yml
+++ b/.github/workflows/build-capacitor-ios.yml
@@ -1,0 +1,86 @@
+name: Capacitor iOS Build
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - capacitor-version: '6'
+            xcode-version: '15.4'
+            runner: macos-14
+          - capacitor-version: '7'
+            xcode-version: '15.4'
+            runner: macos-14
+          - capacitor-version: '8'
+            xcode-version: '26.0'
+            runner: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+
+      - name: Install dependencies and build TypeScript
+        run: |
+          npm ci
+          npx tsc
+
+      - name: Create test app
+        run: |
+          mkdir test-cap-app && cd test-cap-app
+          npm init -y
+          npm install @capacitor/core@${{ matrix.capacitor-version }} @capacitor/ios@${{ matrix.capacitor-version }} @capacitor/cli@${{ matrix.capacitor-version }}
+          echo '{"appId":"com.test.app","appName":"TestApp","webDir":"dist"}' > capacitor.config.json
+          mkdir -p dist
+          echo '<html><body></body></html>' > dist/index.html
+          npx cap add ios
+          # Log which package manager was used
+          if [ -d ios/App/CapApp-SPM ]; then
+            echo "::notice::Capacitor ${{ matrix.capacitor-version }} uses SPM"
+          else
+            echo "::notice::Capacitor ${{ matrix.capacitor-version }} uses CocoaPods"
+          fi
+
+      - name: Install plugin
+        run: |
+          cd test-cap-app
+          # Plugin requires iOS 15.0 (StoreKit 2) — bump Podfile target if CocoaPods
+          if [ -f ios/App/Podfile ]; then
+            sed -i '' "s/platform :ios, '1[34].0'/platform :ios, '15.0'/" ios/App/Podfile
+          fi
+          cp "$GITHUB_WORKSPACE/www/store.js" "$GITHUB_WORKSPACE/capacitor/www/store.js"
+          cp "$GITHUB_WORKSPACE/www/store.d.ts" "$GITHUB_WORKSPACE/capacitor/www/store.d.ts"
+          npm install "$GITHUB_WORKSPACE/capacitor"
+          npx cap sync ios
+
+      - name: Build iOS
+        run: |
+          cd test-cap-app/ios/App
+          # Use workspace if CocoaPods (Podfile.lock exists), plain scheme if SPM
+          if [ -f Podfile.lock ]; then
+            BUILD_ARGS="-workspace App.xcworkspace"
+          else
+            BUILD_ARGS=""
+          fi
+          xcodebuild build \
+            $BUILD_ARGS \
+            -scheme App \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NODE_MODULES?=node_modules
 
-.PHONY: clean help all build compile typedoc typedoc-dev doc doc-contrib doc-api javalint todo
+.PHONY: clean help all build compile typedoc typedoc-dev doc doc-contrib doc-api javalint todo capacitor-package capacitor-publish check-versions
 
 help:
 	@echo ""
@@ -19,6 +19,9 @@ help:
 	@echo "    typedoc ........... Generate public API reference into api/"
 	@echo "    typedoc-dev ....... Generate developer API reference into api-dev/"
 	@echo "    compile ........... Just compile the typescript code into javascript"
+	@echo "    capacitor-package . Build Capacitor plugin package"
+	@echo "    capacitor-publish . Publish Capacitor plugin to npm"
+	@echo "    check-versions .... Verify all version numbers match"
 	@echo ""
 	@echo "(c)2014-, Jean-Christophe Hoelt <hoelt@fovea.cc>"
 	@echo ""
@@ -28,7 +31,7 @@ help:
 	@#echo "    test-js-coverage .. Test javascript with coverage information."
 	@#echo "    test-install ...... Test plugin installation on iOS and Android."
 
-all: build doc
+all: build doc capacitor-package
 
 build: compile
 	@make tests
@@ -64,6 +67,35 @@ typedoc-dev:
 	@npm run typedoc-dev
 
 doc: typedoc typedoc-dev
+
+# Capacitor plugin packaging
+capacitor-package: compile
+	@echo "Packaging Capacitor plugin..."
+	cp www/store.js capacitor/www/store.js
+	cp www/store.d.ts capacitor/www/store.d.ts
+	@ROOT_VERSION=$$(node -p "require('./package.json').version"); \
+	CAP_VERSION=$$(node -p "require('./capacitor/package.json').version"); \
+	if [ "$$ROOT_VERSION" != "$$CAP_VERSION" ]; then \
+		echo "ERROR: Version mismatch! root=$$ROOT_VERSION capacitor=$$CAP_VERSION"; \
+		exit 1; \
+	fi
+	@echo "Capacitor package ready (version $$(node -p "require('./capacitor/package.json').version"))"
+
+capacitor-publish: capacitor-package
+	cd capacitor && npm publish
+
+check-versions:
+	@ROOT_VERSION=$$(node -p "require('./package.json').version"); \
+	CAP_VERSION=$$(node -p "require('./capacitor/package.json').version"); \
+	XML_VERSION=$$(grep '^\s*version=' plugin.xml | head -1 | sed 's/.*version="\([^"]*\)".*/\1/'); \
+	echo "Root package.json: $$ROOT_VERSION"; \
+	echo "Capacitor package.json: $$CAP_VERSION"; \
+	echo "plugin.xml: $$XML_VERSION"; \
+	if [ "$$ROOT_VERSION" != "$$CAP_VERSION" ] || [ "$$ROOT_VERSION" != "$$XML_VERSION" ]; then \
+		echo "ERROR: Version mismatch!"; \
+		exit 1; \
+	fi; \
+	echo "All versions match: $$ROOT_VERSION"
 
 clean:
 	@find . -name '*~' -exec rm '{}' ';'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cordova Purchase Plugin
+# Cdv Purchase Plugin
 
-> In-App Purchases for Cordova
+> Native Capacitor and Cordova Plugin for In-App Purchases
 
 ---
 
@@ -8,13 +8,13 @@ Need professional help and support? [Contact Me](mailto:hoelt@fovea.cc).
 
 ## Summary
 
-This plugin allows **In-App Purchases** to be made from **Cordova, Ionic and Capacitor** applications.
+This plugin allows **In-App Purchases** to be made from **Capacitor**, **Cordova** and **Ionic** applications.
 
-It lets you handle in-app purchases on many platforms with a single codebase.
+It lets you handle in-app purchases on many platforms with a single codebase. The plugin provides **native implementations** for both Capacitor and Cordova — no compatibility layer needed.
 
-This is a plugin for the **Apache Cordova** framework that provides an easy and flexible way to integrate **in-app purchases** into Cordova-based mobile applications, including popular frameworks such as **Ionic and PhoneGap**. With this plugin, you can easily add support for in-app purchases of digital content, such as subscriptions, consumables, and non-consumables, using the store-specific purchase APIs provided by the major mobile platforms. The plugin also supports requesting payments through popular payment providers such as **Braintree**, allowing you to easily accept payments from your users.
+This plugin provides an easy and flexible way to integrate **in-app purchases** into your mobile applications. You can easily add support for in-app purchases of digital content, such as subscriptions, consumables, and non-consumables, using the store-specific purchase APIs provided by the major mobile platforms. The plugin also supports requesting payments through popular payment providers such as **Braintree**, allowing you to easily accept payments from your users.
 
-The Cordova-Plugin-Purchase plugin is designed to be easy to use and integrate into your Cordova app, and it provides a consistent API across all supported platforms, so you can focus on building your app without worrying about platform-specific differences. Whether you are building a subscription-based app, a freemium app, or any other app that requires in-app purchases, the Cordova-Plugin-Purchase plugin can help you get started quickly and easily.
+The plugin is designed to be easy to use and provides a consistent API across all supported platforms, so you can focus on building your app without worrying about platform-specific differences. Whether you are building a subscription-based app, a freemium app, or any other app that requires in-app purchases, this plugin can help you get started quickly and easily.
 
 ### Features
 

--- a/capacitor/.gitignore
+++ b/capacitor/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+www/store.js
+www/store.d.ts
+android/build/

--- a/capacitor/CONTRIBUTING.md
+++ b/capacitor/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+## Podspec naming convention
+
+Capacitor CLI derives the CocoaPods pod name from the npm package name:
+
+```
+npm: capacitor-plugin-cdv-purchase → pod: CapacitorPluginCdvPurchase
+```
+
+The podspec filename and `s.name` must match this derived name exactly. A mismatch causes "No podspec found" during `pod install`.
+
+There are two podspecs:
+- `CapacitorPluginCdvPurchase.podspec` — root-level, used by Capacitor CLI (paths relative to package root)
+- `ios/CapacitorPluginPurchase.podspec` — legacy (paths relative to `ios/`)
+
+## iOS availability guards
+
+The plugin targets iOS 15.0 but some APIs require newer versions:
+
+- `AppTransaction.shared` — requires `#available(iOS 16.0, *)`
+- `AppStore.presentOfferCodeRedeemSheet` — requires `#available(iOS 16.0, *)`
+- `Locale.region` — requires `#available(iOS 16.0, *)`
+
+Always wrap these in availability checks with a fallback.
+
+## SPM and Xcode version requirements
+
+Capacitor 8 defaults to SPM and distributes its iOS framework as a precompiled `.xcframework` via `capacitor-swift-pm`. The xcframework is compiled with **Xcode 26** (Swift 6.2+), which enables `$NonescapableTypes` by default. The `.swiftinterface` files gate extension methods (`reject()`, `getString()`, `getBool()`, etc.) behind this compiler feature flag.
+
+**This means Capacitor 8 + SPM requires Xcode 26.** With the correct Xcode version, all APIs work natively — no workarounds needed. Use idiomatic Capacitor APIs in the plugin code.
+
+Capacitor 6 and 7 use CocoaPods by default, which compiles from source. Any Xcode version that supports the deployment target (15.0) works.
+
+## CI matrix
+
+| Capacitor | Runner   | Xcode | Package Manager |
+|-----------|----------|-------|-----------------|
+| 6         | macOS-14 | 15.4  | CocoaPods       |
+| 7         | macOS-14 | 15.4  | CocoaPods       |
+| 8         | macOS-15 | 26.0  | SPM             |
+
+## CI environment notes
+
+- **macOS-15 + Xcode 16.2** fails with "iOS 18.2 Platform Not Installed" on storyboard compilation. Use Xcode 26 (for Cap 8) or macOS-14 + Xcode 15.4 (for Cap 6/7).
+- **`@capacitor/create-app`** always scaffolds the latest template (Cap 8 / SPM) regardless of CLI version. For testing older versions, scaffold manually with `npm init` + pinned deps.
+- **Podfile deployment target**: Cap 6/7 generate Podfiles defaulting to iOS 13.0/14.0. The plugin needs 15.0 — CI patches this with `sed`.
+- **Ruby version conflicts** on macOS: `pod` (Homebrew) and `gem` (system) may point to different Ruby versions. Install gems with the Homebrew Ruby if needed.

--- a/capacitor/CapacitorPluginCdvPurchase.podspec
+++ b/capacitor/CapacitorPluginCdvPurchase.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = 'CapacitorPluginCdvPurchase'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+  s.homepage     = package['repository']['url']
+  s.author       = 'Jean-Christophe Hoelt'
+  s.source       = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.source_files = 'ios/Sources/PurchasePlugin/**/*.{swift,h,m}'
+  s.ios.deployment_target = '13.0'
+  s.swift_version = '5.9'
+  s.dependency 'Capacitor'
+  s.frameworks   = 'StoreKit'
+end

--- a/capacitor/Package.swift
+++ b/capacitor/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "CapacitorPluginCdvPurchase",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "CapacitorPluginCdvPurchase",
+            targets: ["PurchasePlugin"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", "6.0.0"..<"10.0.0")
+    ],
+    targets: [
+        .target(
+            name: "PurchasePlugin",
+            dependencies: [
+                .product(name: "Capacitor", package: "capacitor-swift-pm"),
+                .product(name: "Cordova", package: "capacitor-swift-pm")
+            ],
+            path: "ios/Sources/PurchasePlugin",
+            swiftSettings: [
+                .enableExperimentalFeature("NonescapableTypes")
+            ])
+    ]
+)

--- a/capacitor/README.md
+++ b/capacitor/README.md
@@ -1,0 +1,61 @@
+# capacitor-plugin-cdv-purchase
+
+In-App Purchase plugin for Capacitor 6+ — iOS (StoreKit 2) and Android (Google Play Billing).
+
+This is the Capacitor edition of [cordova-plugin-purchase](https://github.com/j3k0/cordova-plugin-purchase), sharing the same API and adapter layer.
+
+## Installation
+
+```bash
+npm install capacitor-plugin-cdv-purchase
+npx cap sync
+```
+
+## Usage
+
+```typescript
+import 'capacitor-plugin-cdv-purchase';
+
+const { Store, ProductType, Platform } = CdvPurchase;
+const store = new Store();
+
+// Register products
+store.register([{
+  id: 'my_subscription',
+  type: ProductType.PAID_SUBSCRIPTION,
+  platform: Platform.GOOGLE_PLAY, // or Platform.APPLE_APPSTORE
+}]);
+
+// Listen for events
+store.when()
+  .productUpdated((product) => { console.log('Product updated:', product); })
+  .approved((transaction) => transaction.verify())
+  .verified((receipt) => receipt.finish());
+
+// Initialize
+await store.initialize();
+```
+
+## Migrating from cordova-plugin-purchase
+
+If you're using `cordova-plugin-purchase` in a Capacitor app:
+
+1. `npm install capacitor-plugin-cdv-purchase`
+2. `npx cap sync`
+3. Your code stays the same — the `CdvPurchase.Store` API is identical
+4. Once confirmed working: `npm uninstall cordova-plugin-purchase`
+
+## Platform Support
+
+| Platform | Native API | Minimum OS |
+|----------|-----------|------------|
+| iOS      | StoreKit 2 | iOS 15+    |
+| Android  | Google Play Billing 8.3 | API 23+ |
+
+## Documentation
+
+Full API documentation: https://github.com/j3k0/cordova-plugin-purchase/blob/master/doc/api.md
+
+## License
+
+MIT

--- a/capacitor/TROUBLESHOOTING.md
+++ b/capacitor/TROUBLESHOOTING.md
@@ -1,0 +1,46 @@
+# Troubleshooting
+
+## iOS requires minimum deployment target 15.0
+
+This plugin uses **StoreKit 2**, which requires **iOS 15.0**. Capacitor 6 and 7 generate Podfiles with a lower default. Open `ios/App/Podfile` and update:
+
+```ruby
+# Change this:
+platform :ios, '13.0'
+# To this:
+platform :ios, '15.0'
+```
+
+Then run `npx cap sync ios`.
+
+## "No podspec found for CapacitorPluginCdvPurchase"
+
+Make sure you're on the latest version of the plugin. If you're using a local path (`file:../path`), verify the podspec exists at the plugin package root.
+
+## Different bundle IDs on iOS and Android
+
+Capacitor does not support per-platform `appId` in `capacitor.config.json` — it's a single global value. If your iOS and Android apps have different bundle IDs, you'll need to change `appId` when switching platforms, or use Xcode schemes (iOS) / product flavors (Android) for overrides.
+
+## Testing on Mac (Catalyst)
+
+To test on your Mac without a physical device:
+
+1. `npx cap open ios`
+2. In Xcode, select your Mac as the destination ("My Mac (Designed for iPad)" or "My Mac (Mac Catalyst)")
+3. Set your signing team and build
+
+This works for testing the purchase flow with sandbox accounts.
+
+## Capacitor 8 / SPM requires Xcode 26
+
+Capacitor 8 defaults to Swift Package Manager (SPM). The Capacitor xcframework is compiled with Xcode 26 (Swift 6.2+), so **you need Xcode 26 or later** to build.
+
+If you see errors like `value of type 'CAPPluginCall' has no member 'reject'`, your Xcode is too old. Update to Xcode 26+.
+
+As a fallback, you can use CocoaPods instead:
+
+```bash
+rm -rf ios
+npx cap add ios --packagemanager CocoaPods
+npx cap sync ios
+```

--- a/capacitor/android/build.gradle
+++ b/capacitor/android/build.gradle
@@ -1,0 +1,42 @@
+ext {
+    junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.0'
+}
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.7.3'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    namespace "cc.fovea.iap"
+    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 35
+    defaultConfig {
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 23
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 35
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':capacitor-android')
+    implementation 'com.android.billingclient:billing:8.3.0'
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    testImplementation "junit:junit:$junitVersion"
+}

--- a/capacitor/android/src/main/AndroidManifest.xml
+++ b/capacitor/android/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="cc.fovea.iap">
+    <uses-permission android:name="com.android.vending.BILLING" />
+</manifest>

--- a/capacitor/android/src/main/java/cc/fovea/iap/PurchasePlugin.java
+++ b/capacitor/android/src/main/java/cc/fovea/iap/PurchasePlugin.java
@@ -1,0 +1,1206 @@
+/**
+ * The Capacitor Purchase Plugin for Google Play.
+ *
+ * Wraps Google Play BillingClient 8.3.0 and communicates with the TypeScript
+ * CapacitorBridge via Capacitor's plugin API.
+ *
+ * JSON formats for purchases and products match the existing Cordova plugin
+ * format so the same TypeScript adapter code can parse them.
+ *
+ * @author Jean-Christophe Hoelt - Fovea.cc
+ */
+
+package cc.fovea.iap;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Log;
+
+import com.android.billingclient.api.AcknowledgePurchaseParams;
+import com.android.billingclient.api.AcknowledgePurchaseResponseListener;
+import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.BillingClient.BillingResponseCode;
+import com.android.billingclient.api.BillingClient.FeatureType;
+import com.android.billingclient.api.BillingClient.ProductType;
+import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingFlowParams;
+import com.android.billingclient.api.BillingFlowParams.ProductDetailsParams;
+import com.android.billingclient.api.BillingResult;
+import com.android.billingclient.api.ConsumeParams;
+import com.android.billingclient.api.ConsumeResponseListener;
+import com.android.billingclient.api.PendingPurchasesParams;
+import com.android.billingclient.api.ProductDetails;
+import com.android.billingclient.api.ProductDetails.OneTimePurchaseOfferDetails;
+import com.android.billingclient.api.ProductDetails.PricingPhase;
+import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails;
+import com.android.billingclient.api.ProductDetailsResponseListener;
+import com.android.billingclient.api.Purchase;
+import com.android.billingclient.api.PurchasesResponseListener;
+import com.android.billingclient.api.PurchasesUpdatedListener;
+import com.android.billingclient.api.QueryProductDetailsParams;
+import com.android.billingclient.api.QueryProductDetailsParams.Product;
+import com.android.billingclient.api.QueryProductDetailsResult;
+import com.android.billingclient.api.QueryPurchasesParams;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@CapacitorPlugin(name = "PurchasePlugin")
+public class PurchasePlugin extends Plugin implements
+        PurchasesUpdatedListener {
+
+    private static final String TAG = "CdvPurchase";
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    /** A reference to BillingClient. */
+    private BillingClient mBillingClient;
+
+    /** List of registered IN_APP product identifiers. */
+    private final List<String> mInAppProductIds = new ArrayList<>();
+
+    /** List of registered SUBS product identifiers. */
+    private final List<String> mSubsProductIds = new ArrayList<>();
+
+    /** List of purchases reported by the Billing library. */
+    private final List<Purchase> mPurchases = new ArrayList<>();
+
+    /** True if billing service is connected now. */
+    private boolean mIsServiceConnected;
+
+    /** Value for mBillingClientResult until BillingClient is connected. */
+    private static final int BILLING_CLIENT_NOT_CONNECTED = -1;
+
+    /** Last response from the billing client. */
+    private BillingResult mBillingClientResult = BillingResult.newBuilder()
+            .setResponseCode(BILLING_CLIENT_NOT_CONNECTED).build();
+
+    /** Product details loaded from GooglePlay, indexed by product identifier. */
+    private final HashMap<String, ProductDetails> mProductDetails = new HashMap<>();
+
+    /** List of purchase tokens being consumed. */
+    private final Set<String> mTokensToBeConsumed = new HashSet<>();
+
+    /** Purchases indexed by token, for lookup when consuming. (CRITICAL 5) */
+    private final HashMap<String, Purchase> mPurchasesByToken = new HashMap<>();
+
+    /** Pending call for buy/subscribe (resolved in onPurchasesUpdated). */
+    private PluginCall mPendingBuyCall;
+
+    /** Pending call for consumePurchase (async callback, CRITICAL 6). */
+    private PluginCall mPendingConsumeCall;
+
+    /** Pending call for acknowledgePurchase (async callback, CRITICAL 6). */
+    private PluginCall mPendingAcknowledgeCall;
+
+    /** Last time onStart refreshed purchases. */
+    private long mLastQueryOnStart = 0;
+
+    /** Intermediate results for parallel purchase queries. */
+    private BillingResult mInAppResult;
+    private BillingResult mSubsResult;
+    private int nProductDetailsQuerySuccessful = 0;
+
+    // -------------------------------------------------------------------------
+    // Internal callback interface for product details queries
+    // -------------------------------------------------------------------------
+
+    private interface InternalProductDetailsResponseListener {
+        void onProductDetailsResponse(BillingResult result,
+                                      List<ProductDetails> productDetailsList);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private BillingResult getLastResult() {
+        return mBillingClientResult;
+    }
+
+    private int getLastResponseCode() {
+        return mBillingClientResult.getResponseCode();
+    }
+
+    private void resetLastResult(final int responseCode) {
+        mBillingClientResult = BillingResult.newBuilder()
+                .setResponseCode(responseCode)
+                .setDebugMessage("")
+                .build();
+    }
+
+    private void addInAppProductIds(final List<String> list) {
+        for (int i = 0; i < list.size(); ++i) {
+            if (!mInAppProductIds.contains(list.get(i))) {
+                mInAppProductIds.add(list.get(i));
+            }
+        }
+    }
+
+    private void addSubsProductIds(final List<String> list) {
+        for (int i = 0; i < list.size(); ++i) {
+            if (!mSubsProductIds.contains(list.get(i))) {
+                mSubsProductIds.add(list.get(i));
+            }
+        }
+    }
+
+    /** Store a purchase in the lookup maps. */
+    private void storePurchase(Purchase p) {
+        mPurchases.add(0, p);
+        mPurchasesByToken.put(p.getPurchaseToken(), p);
+    }
+
+    private Purchase findPurchaseByToken(final String purchaseToken) {
+        Purchase p = mPurchasesByToken.get(purchaseToken);
+        if (p != null) return p;
+        // Fallback: linear scan
+        for (Purchase purchase : mPurchases) {
+            if (purchase.getPurchaseToken().equals(purchaseToken))
+                return purchase;
+        }
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON conversion — MUST match Cordova plugin format
+    // -------------------------------------------------------------------------
+
+    /**
+     * Convert a Purchase to JSON.
+     * CRITICAL 1: starts from getOriginalJson() and overlays fields.
+     */
+    private JSONObject purchaseToJson(final Purchase p) throws JSONException {
+        return new JSONObject(p.getOriginalJson())
+                .put("productIds", new JSONArray(p.getProducts()))
+                .put("orderId", p.getOrderId())
+                .put("getPurchaseState", p.getPurchaseState())
+                .put("developerPayload", p.getDeveloperPayload())
+                .put("acknowledged", p.isAcknowledged())
+                .put("autoRenewing", p.isAutoRenewing())
+                .put("accountId", p.getAccountIdentifiers() != null
+                        ? p.getAccountIdentifiers().getObfuscatedAccountId() : null)
+                .put("profileId", p.getAccountIdentifiers() != null
+                        ? p.getAccountIdentifiers().getObfuscatedProfileId() : null)
+                .put("signature", p.getSignature())
+                .put("receipt", p.getOriginalJson().toString())
+                .put("quantity", p.getQuantity());
+    }
+
+    /** Convert a list of purchases to a JSONArray. */
+    private JSONArray purchasesToJson(final List<Purchase> purchaseList)
+            throws JSONException {
+        JSONArray arr = new JSONArray();
+        for (Purchase p : purchaseList) {
+            arr.put(purchaseToJson(p));
+        }
+        return arr;
+    }
+
+    /**
+     * Convert ProductDetails to JSON.
+     * CRITICAL 3: handles BillingClient 8.x multi-offer INAPP format.
+     * CRITICAL 4: recurrence_mode is a string enum.
+     */
+    private JSONObject productDetailsToJson(ProductDetails product)
+            throws JSONException {
+        JSONObject ret = new JSONObject()
+                .put("productId", product.getProductId())
+                .put("title", product.getTitle())
+                .put("name", product.getName())
+                .put("description", product.getDescription());
+
+        if (product.getProductType().equals(ProductType.INAPP)) {
+            // Check for multiple offers (new in Billing Library 8.0.0)
+            List<OneTimePurchaseOfferDetails> offerList =
+                    product.getOneTimePurchaseOfferDetailsList();
+
+            if (offerList != null && offerList.size() > 1) {
+                // Multiple offers — v12.0 format with offers array
+                ret.put("product_format", "v12.0")
+                   .put("product_type", "inapp");
+                JSONArray offers = new JSONArray();
+                for (OneTimePurchaseOfferDetails offer : offerList) {
+                    JSONObject offerJson = new JSONObject()
+                            .put("offer_id", offer.getOfferId())
+                            .put("offer_token", offer.getOfferToken())
+                            .put("formatted_price", offer.getFormattedPrice())
+                            .put("price_amount_micros", offer.getPriceAmountMicros())
+                            .put("price_currency_code", offer.getPriceCurrencyCode());
+                    offers.put(offerJson);
+                }
+                ret.put("offers", offers);
+            } else {
+                // Single offer — legacy v11.0 format
+                final OneTimePurchaseOfferDetails details =
+                        product.getOneTimePurchaseOfferDetails();
+                ret.put("product_type", "inapp")
+                   .put("product_format", "v11.0")
+                   .put("formatted_price", details.getFormattedPrice())
+                   .put("price_amount_micros", details.getPriceAmountMicros())
+                   .put("price_currency_code", details.getPriceCurrencyCode());
+            }
+        } else if (product.getProductType().equals(ProductType.SUBS)) {
+            // Subscriptions — v12.0 format
+            ret.put("product_format", "v12.0")
+               .put("product_type", "subs");
+            JSONArray offers = new JSONArray();
+            List<SubscriptionOfferDetails> subscriptionOfferDetailsList =
+                    product.getSubscriptionOfferDetails();
+            for (SubscriptionOfferDetails details : subscriptionOfferDetailsList) {
+                JSONObject offer = new JSONObject()
+                        .put("base_plan_id", details.getBasePlanId())
+                        .put("offer_id", details.getOfferId())
+                        .put("token", details.getOfferToken())
+                        .put("tags", new JSONArray(details.getOfferTags()));
+                JSONArray pricingPhases = new JSONArray();
+                if (details.getPricingPhases() != null) {
+                    for (PricingPhase pricing :
+                            details.getPricingPhases().getPricingPhaseList()) {
+                        JSONObject pricingPhase = new JSONObject()
+                                .put("billing_cycle_count",
+                                        pricing.getBillingCycleCount())
+                                .put("billing_period",
+                                        pricing.getBillingPeriod())
+                                .put("formatted_price",
+                                        pricing.getFormattedPrice())
+                                .put("price_amount_micros",
+                                        pricing.getPriceAmountMicros())
+                                .put("price_currency_code",
+                                        pricing.getPriceCurrencyCode());
+                        // CRITICAL 4: string enum, not integer
+                        if (pricing.getRecurrenceMode()
+                                == ProductDetails.RecurrenceMode.FINITE_RECURRING) {
+                            pricingPhase.put("recurrence_mode",
+                                    "FINITE_RECURRING");
+                        } else if (pricing.getRecurrenceMode()
+                                == ProductDetails.RecurrenceMode.INFINITE_RECURRING) {
+                            pricingPhase.put("recurrence_mode",
+                                    "INFINITE_RECURRING");
+                        } else if (pricing.getRecurrenceMode()
+                                == ProductDetails.RecurrenceMode.NON_RECURRING) {
+                            pricingPhase.put("recurrence_mode",
+                                    "NON_RECURRING");
+                        }
+                        pricingPhases.put(pricingPhase);
+                    }
+                } else {
+                    ret.put("product_format", "unknown");
+                }
+                offer.put("pricing_phases", pricingPhases);
+                offers.put(offer);
+            }
+            ret.put("offers", offers);
+        }
+        return ret;
+    }
+
+    // -------------------------------------------------------------------------
+    // Billing response code helpers (from Cordova plugin)
+    // -------------------------------------------------------------------------
+
+    private String codeToString(int code) {
+        switch (code) {
+            case BillingResponseCode.BILLING_UNAVAILABLE:
+                return "BILLING_UNAVAILABLE";
+            case BillingResponseCode.DEVELOPER_ERROR:
+                return "DEVELOPER_ERROR";
+            case BillingResponseCode.ERROR:
+                return "ERROR";
+            case BillingResponseCode.FEATURE_NOT_SUPPORTED:
+                return "FEATURE_NOT_SUPPORTED";
+            case BillingResponseCode.ITEM_ALREADY_OWNED:
+                return "ITEM_ALREADY_OWNED";
+            case BillingResponseCode.ITEM_NOT_OWNED:
+                return "ITEM_NOT_OWNED";
+            case BillingResponseCode.ITEM_UNAVAILABLE:
+                return "ITEM_UNAVAILABLE";
+            case BillingResponseCode.OK:
+                return "OK";
+            case BillingResponseCode.SERVICE_DISCONNECTED:
+                return "SERVICE_DISCONNECTED";
+            case BillingResponseCode.SERVICE_TIMEOUT:
+                return "SERVICE_TIMEOUT";
+            case BillingResponseCode.SERVICE_UNAVAILABLE:
+                return "SERVICE_UNAVAILABLE";
+            case BillingResponseCode.USER_CANCELED:
+                return "USER_CANCELED";
+            default:
+                return "CODE_" + code;
+        }
+    }
+
+    private String codeToMessage(int code) {
+        switch (code) {
+            case BillingResponseCode.BILLING_UNAVAILABLE:
+                return "Billing API version is not supported for the type requested";
+            case BillingResponseCode.DEVELOPER_ERROR:
+                return "Invalid arguments provided to the API";
+            case BillingResponseCode.ERROR:
+                return "Fatal error during the API action";
+            case BillingResponseCode.FEATURE_NOT_SUPPORTED:
+                return "Requested feature is not supported by Play Store on the current device";
+            case BillingResponseCode.ITEM_ALREADY_OWNED:
+                return "Failure to purchase since item is already owned";
+            case BillingResponseCode.ITEM_NOT_OWNED:
+                return "Failure to consume since item is not owned";
+            case BillingResponseCode.ITEM_UNAVAILABLE:
+                return "Requested product is not available for purchase";
+            case BillingResponseCode.OK:
+                return "Success";
+            case BillingResponseCode.SERVICE_DISCONNECTED:
+                return "Play Store service is not connected now - potentially transient state";
+            case BillingResponseCode.SERVICE_TIMEOUT:
+                return "The request has reached the maximum timeout before Google Play responds";
+            case BillingResponseCode.SERVICE_UNAVAILABLE:
+                return "Network connection is down";
+            case BillingResponseCode.USER_CANCELED:
+                return "User pressed back or canceled a dialog";
+            default:
+                return "Unknown error code";
+        }
+    }
+
+    private String format(final BillingResult result) {
+        final int code = result.getResponseCode();
+        final String message =
+                !result.getDebugMessage().isEmpty()
+                        ? result.getDebugMessage()
+                        : codeToMessage(code);
+        return codeToString(code) + ": " + message;
+    }
+
+    // -------------------------------------------------------------------------
+    // BillingClient connection management
+    // -------------------------------------------------------------------------
+
+    private void startServiceConnection(final Runnable executeOnSuccess,
+                                        final Runnable executeOnFailure) {
+        Log.d(TAG, "startServiceConnection()");
+        mBillingClient.startConnection(new BillingClientStateListener() {
+            @Override
+            public void onBillingSetupFinished(final BillingResult result) {
+                mBillingClientResult = result;
+                if (result.getResponseCode() == BillingResponseCode.OK) {
+                    Log.d(TAG, "startServiceConnection() -> Success");
+                    mIsServiceConnected = true;
+                    if (executeOnSuccess != null) {
+                        executeOnSuccess.run();
+                    }
+                } else {
+                    Log.d(TAG, "startServiceConnection() -> Failed: "
+                            + format(getLastResult()));
+                    mIsServiceConnected = false;
+                    if (executeOnFailure != null) {
+                        executeOnFailure.run();
+                    }
+                }
+            }
+
+            @Override
+            public void onBillingServiceDisconnected() {
+                Log.d(TAG, "startServiceConnection() -> Disconnected");
+                mIsServiceConnected = false;
+            }
+        });
+    }
+
+    private void executeServiceRequest(final Runnable runnable) {
+        if (mIsServiceConnected) {
+            Log.d(TAG, "executeServiceRequest() -> OK");
+            resetLastResult(BillingResponseCode.OK);
+            runnable.run();
+        } else {
+            Log.d(TAG, "executeServiceRequest() -> Failed (try again).");
+            startServiceConnection(runnable, () -> {
+                Log.d(TAG, "executeServiceRequest() -> "
+                        + "Failed to reconnect to billing server...");
+            });
+        }
+    }
+
+    public boolean areSubscriptionsSupported() {
+        BillingResult result =
+                mBillingClient.isFeatureSupported(FeatureType.SUBSCRIPTIONS);
+        if (result.getResponseCode() != BillingResponseCode.OK) {
+            Log.w(TAG, "areSubscriptionsSupported() -> Failed: "
+                    + format(result));
+            return false;
+        }
+        return true;
+    }
+
+    // -------------------------------------------------------------------------
+    // Capacitor lifecycle
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void load() {
+        super.load();
+    }
+
+    @Override
+    protected void handleOnStart() {
+        super.handleOnStart();
+        Log.d(TAG, "handleOnStart()");
+        if (mBillingClient != null) {
+            long now = Calendar.getInstance().getTimeInMillis();
+            if (now - mLastQueryOnStart > 24 * 60 * 60 * 1000) {
+                mLastQueryOnStart = Calendar.getInstance().getTimeInMillis();
+                queryPurchases();
+            }
+        }
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        if (mBillingClient != null && mBillingClient.isReady()) {
+            mBillingClient.endConnection();
+        }
+        super.handleOnDestroy();
+    }
+
+    // -------------------------------------------------------------------------
+    // Plugin methods — called from TypeScript via Capacitor
+    // -------------------------------------------------------------------------
+
+    /**
+     * Initialize the Google Play BillingClient.
+     * CRITICAL 2: enablePendingPurchases with new API.
+     */
+    @PluginMethod
+    public void init(PluginCall call) {
+        Log.d(TAG, "init()");
+
+        mBillingClient = BillingClient
+                .newBuilder(getContext())
+                .enablePendingPurchases(
+                        PendingPurchasesParams.newBuilder()
+                                .enableOneTimeProducts()
+                                .enablePrepaidPlans()
+                                .build())
+                .setListener(this)
+                .build();
+
+        resetLastResult(BILLING_CLIENT_NOT_CONNECTED);
+        startServiceConnection(() -> {
+            if (getLastResponseCode() == BillingResponseCode.OK) {
+                Log.d(TAG, "init() -> Success");
+                call.resolve();
+            } else {
+                Log.d(TAG, "init() -> Failed: " + format(getLastResult()));
+                call.reject("Setup failed. " + format(getLastResult()));
+            }
+        }, () -> {
+            Log.d(TAG, "init() -> Failure: " + format(getLastResult()));
+            call.reject("Setup failure. " + format(getLastResult()));
+        });
+    }
+
+    /**
+     * Query available products (INAPP + SUBS).
+     * Returns { products: [...] } matching the CapacitorBridge expectation.
+     */
+    @PluginMethod
+    public void getAvailableProducts(PluginCall call) {
+        Log.d(TAG, "getAvailableProducts()");
+        try {
+            final JSObject args = call.getData();
+            final JSONArray inAppArr = args.getJSONArray("inAppSkus");
+            final JSONArray subsArr = args.getJSONArray("subsSkus");
+            List<String> inAppSkus = jsonArrayToStringList(inAppArr);
+            List<String> subsSkus = jsonArrayToStringList(subsArr);
+            addInAppProductIds(inAppSkus);
+            addSubsProductIds(subsSkus);
+
+            queryAllProductDetails(mInAppProductIds, mSubsProductIds,
+                    (result, productDetailsList) -> {
+                if (result.getResponseCode() != BillingResponseCode.OK) {
+                    Log.d(TAG, "getAvailableProducts() -> Failed: "
+                            + format(result));
+                    call.reject("Failed to load Products, code: "
+                            + result.getResponseCode());
+                    return;
+                }
+                try {
+                    JSONArray jsonProductList = new JSONArray();
+                    for (ProductDetails product : productDetailsList) {
+                        Log.d(TAG, "getAvailableProducts() -> productDetails: "
+                                + product.toString());
+                        jsonProductList.put(productDetailsToJson(product));
+                    }
+                    Log.d(TAG, "getAvailableProducts() -> Success");
+                    JSObject ret = new JSObject();
+                    ret.put("products", jsonProductList);
+                    call.resolve(ret);
+                } catch (JSONException e) {
+                    Log.d(TAG, "getAvailableProducts() -> Failed: "
+                            + e.getMessage());
+                    call.reject(e.getMessage());
+                }
+            });
+        } catch (JSONException e) {
+            call.reject("Invalid parameters: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Query existing purchases. Results arrive via the "setPurchases" event.
+     */
+    @PluginMethod
+    public void getPurchases(PluginCall call) {
+        Log.d(TAG, "getPurchases()");
+        queryPurchases();
+        call.resolve();
+    }
+
+    /**
+     * Initiate a purchase flow (INAPP).
+     */
+    @PluginMethod
+    public void buy(PluginCall call) {
+        Log.d(TAG, "buy()");
+        try {
+            final String productId = call.getString("productId");
+            final JSONObject additionalData = call.getData().has("additionalData")
+                    ? new JSONObject(call.getObject("additionalData").toString())
+                    : new JSONObject();
+            BillingFlowParams params =
+                    parseBillingFlowParams(productId, additionalData, call);
+            if (params != null) {
+                initiatePurchaseFlow(params, call);
+            }
+            // If params == null, parseBillingFlowParams already called
+            // call.reject().
+        } catch (JSONException e) {
+            call.reject(e.getMessage());
+        }
+    }
+
+    /**
+     * Initiate a subscription flow.
+     */
+    @PluginMethod
+    public void subscribe(PluginCall call) {
+        Log.d(TAG, "subscribe()");
+        if (!areSubscriptionsSupported()) {
+            call.reject("FEATURE_NOT_SUPPORTED");
+            return;
+        }
+        try {
+            final String productId = call.getString("productId");
+            final JSONObject additionalData = call.getData().has("additionalData")
+                    ? new JSONObject(call.getObject("additionalData").toString())
+                    : new JSONObject();
+            BillingFlowParams params =
+                    parseBillingFlowParams(productId, additionalData, call);
+            if (params != null) {
+                initiatePurchaseFlow(params, call);
+            }
+        } catch (JSONException e) {
+            call.reject(e.getMessage());
+        }
+    }
+
+    /**
+     * Consume a purchase.
+     * CRITICAL 6: store PluginCall and resolve in async callback.
+     */
+    @PluginMethod
+    public void consumePurchase(PluginCall call) {
+        final String purchaseToken = call.getString("purchaseToken");
+        Log.d(TAG, "consumePurchase(" + purchaseToken + ")");
+
+        if (mTokensToBeConsumed.contains(purchaseToken)) {
+            Log.i(TAG, "consumePurchase() -> Consume already in progress.");
+            call.reject("ITEM_ALREADY_CONSUMED");
+            return;
+        }
+        mTokensToBeConsumed.add(purchaseToken);
+        mPendingConsumeCall = call;
+
+        executeServiceRequest(() -> {
+            final ConsumeParams params = ConsumeParams.newBuilder()
+                    .setPurchaseToken(purchaseToken)
+                    .build();
+            mBillingClient.consumeAsync(params, (result, token) -> {
+                onConsumeResponse(result, token);
+            });
+        });
+    }
+
+    /**
+     * Acknowledge a purchase.
+     * CRITICAL 6: store PluginCall and resolve in async callback.
+     */
+    @PluginMethod
+    public void acknowledgePurchase(PluginCall call) {
+        final String purchaseToken = call.getString("purchaseToken");
+        Log.d(TAG, "acknowledgePurchase(" + purchaseToken + ")");
+
+        mPendingAcknowledgeCall = call;
+
+        executeServiceRequest(() -> {
+            final AcknowledgePurchaseParams params =
+                    AcknowledgePurchaseParams.newBuilder()
+                            .setPurchaseToken(purchaseToken)
+                            .build();
+            mBillingClient.acknowledgePurchase(params, result -> {
+                onAcknowledgePurchaseResponse(result);
+            });
+        });
+    }
+
+    /**
+     * Finish/acknowledge a transaction (generic form used by the bridge).
+     * For Android this is an alias for acknowledgePurchase using
+     * transactionId as the purchase token.
+     */
+    @PluginMethod
+    public void finish(PluginCall call) {
+        final String transactionId = call.getString("transactionId");
+        Log.d(TAG, "finish(" + transactionId + ")");
+
+        mPendingAcknowledgeCall = call;
+
+        executeServiceRequest(() -> {
+            final AcknowledgePurchaseParams params =
+                    AcknowledgePurchaseParams.newBuilder()
+                            .setPurchaseToken(transactionId)
+                            .build();
+            mBillingClient.acknowledgePurchase(params, result -> {
+                onAcknowledgePurchaseResponse(result);
+            });
+        });
+    }
+
+    /**
+     * CRITICAL 7: open subscription management via Intent deep link.
+     */
+    @PluginMethod
+    public void manageSubscriptions(PluginCall call) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW,
+                Uri.parse("http://play.google.com/store/account/subscriptions"));
+        getActivity().startActivity(browserIntent);
+        call.resolve();
+    }
+
+    /**
+     * CRITICAL 7: open billing management via Intent deep link.
+     */
+    @PluginMethod
+    public void manageBilling(PluginCall call) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW,
+                Uri.parse("http://play.google.com/store/paymentmethods"));
+        getActivity().startActivity(browserIntent);
+        call.resolve();
+    }
+
+    /**
+     * CRITICAL 7: launch price change confirmation flow via deep link.
+     */
+    @PluginMethod
+    public void launchPriceChangeConfirmationFlow(PluginCall call) {
+        final String sku = call.getString("productId");
+        Log.d(TAG, "launchPriceChangeConfirmationFlow(" + sku + ")");
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW,
+                Uri.parse("http://play.google.com/store/account/subscriptions"));
+        getActivity().startActivity(browserIntent);
+        call.resolve();
+    }
+
+    // -------------------------------------------------------------------------
+    // PurchasesUpdatedListener — called by BillingClient after purchase flow
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void onPurchasesUpdated(final BillingResult result,
+                                   final List<Purchase> purchases) {
+        try {
+            final int code = result.getResponseCode();
+            if (code == BillingResponseCode.OK
+                    && purchases != null && purchases.size() > 0) {
+                Log.d(TAG, "onPurchasesUpdated() -> Success");
+                for (Purchase p : purchases) {
+                    storePurchase(p);
+                }
+                JSObject data = new JSObject();
+                data.put("purchases", purchasesToJson(purchases));
+                notifyListeners("purchasesUpdated", data);
+                if (mPendingBuyCall != null) {
+                    mPendingBuyCall.resolve();
+                    mPendingBuyCall = null;
+                }
+            } else if (code == BillingResponseCode.USER_CANCELED) {
+                Log.w(TAG, "onPurchasesUpdated() -> Cancelled: "
+                        + format(result));
+                if (mPendingBuyCall != null) {
+                    mPendingBuyCall.reject("USER_CANCELED", String.valueOf(code));
+                    mPendingBuyCall = null;
+                }
+            } else {
+                Log.w(TAG, "onPurchasesUpdated() -> Failed: "
+                        + format(result));
+                if (mPendingBuyCall != null) {
+                    mPendingBuyCall.reject(format(result), String.valueOf(code));
+                    mPendingBuyCall = null;
+                }
+            }
+        } catch (JSONException e) {
+            Log.w(TAG, "onPurchasesUpdated() -> JSONException "
+                    + e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // ConsumeResponseListener — CRITICAL 5
+    // -------------------------------------------------------------------------
+
+    private void onConsumeResponse(BillingResult result,
+                                   String purchaseToken) {
+        try {
+            Log.d(TAG, "onConsumeResponse()");
+            if (result.getResponseCode() == BillingResponseCode.OK) {
+                mTokensToBeConsumed.remove(purchaseToken);
+                final Purchase purchase = findPurchaseByToken(purchaseToken);
+                Log.d(TAG, "onConsumeResponse() -> Success");
+                // CRITICAL 5: send full Purchase JSON under "purchase" key
+                if (purchase != null) {
+                    JSObject eventData = new JSObject();
+                    eventData.put("purchase", purchaseToJson(purchase));
+                    notifyListeners("purchaseConsumed", eventData);
+                }
+                // Resolve the pending call
+                if (mPendingConsumeCall != null) {
+                    mPendingConsumeCall.resolve();
+                    mPendingConsumeCall = null;
+                }
+            } else {
+                Log.d(TAG, "onConsumeResponse() -> Failed: "
+                        + result.getDebugMessage());
+                if (mPendingConsumeCall != null) {
+                    mPendingConsumeCall.reject(result.getDebugMessage());
+                    mPendingConsumeCall = null;
+                }
+            }
+        } catch (JSONException e) {
+            Log.d(TAG, "onConsumeResponse() -> Failed: " + e.getMessage());
+            if (mPendingConsumeCall != null) {
+                mPendingConsumeCall.reject(e.getMessage());
+                mPendingConsumeCall = null;
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // AcknowledgePurchaseResponseListener
+    // -------------------------------------------------------------------------
+
+    private void onAcknowledgePurchaseResponse(BillingResult result) {
+        if (result.getResponseCode() == BillingResponseCode.OK) {
+            Log.d(TAG, "onAcknowledgePurchaseResponse() -> Success");
+            if (mPendingAcknowledgeCall != null) {
+                mPendingAcknowledgeCall.resolve();
+                mPendingAcknowledgeCall = null;
+            }
+        } else {
+            Log.d(TAG, "onAcknowledgePurchaseResponse() -> Failed: "
+                    + format(result));
+            if (mPendingAcknowledgeCall != null) {
+                mPendingAcknowledgeCall.reject(format(result));
+                mPendingAcknowledgeCall = null;
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Purchase queries
+    // -------------------------------------------------------------------------
+
+    private void queryPurchases() {
+        Log.d(TAG, "queryPurchases()");
+        executeServiceRequest(() -> {
+            long time = System.currentTimeMillis();
+
+            final List<Purchase> allPurchases = new ArrayList<>();
+            mInAppResult = null;
+            mSubsResult = null;
+
+            mBillingClient.queryPurchasesAsync(
+                    QueryPurchasesParams.newBuilder()
+                            .setProductType(ProductType.INAPP).build(),
+                    (billingResult, purchases) -> {
+                        mInAppResult = billingResult;
+                        Log.i(TAG, "queryPurchases(INAPP) -> Elapsed time: "
+                                + (System.currentTimeMillis() - time) + "ms");
+                        if (billingResult.getResponseCode()
+                                == BillingResponseCode.OK) {
+                            allPurchases.addAll(purchases);
+                        }
+                        if (mInAppResult != null
+                                && (mSubsResult != null
+                                || !areSubscriptionsSupported())) {
+                            BillingResult best =
+                                    mInAppResult.getResponseCode()
+                                            == BillingResponseCode.OK
+                                            ? mInAppResult : mSubsResult;
+                            onQueryPurchasesFinished(best, allPurchases);
+                        }
+                    });
+
+            if (areSubscriptionsSupported()) {
+                mBillingClient.queryPurchasesAsync(
+                        QueryPurchasesParams.newBuilder()
+                                .setProductType(ProductType.SUBS).build(),
+                        (billingResult, purchases) -> {
+                            mSubsResult = billingResult;
+                            Log.i(TAG,
+                                    "queryPurchases(SUBS) -> Elapsed time: "
+                                            + (System.currentTimeMillis()
+                                            - time) + "ms");
+                            if (billingResult.getResponseCode()
+                                    == BillingResponseCode.OK) {
+                                allPurchases.addAll(purchases);
+                            }
+                            if (mInAppResult != null
+                                    && (mSubsResult != null
+                                    || !areSubscriptionsSupported())) {
+                                BillingResult best =
+                                        mInAppResult.getResponseCode()
+                                                == BillingResponseCode.OK
+                                                ? mInAppResult : mSubsResult;
+                                onQueryPurchasesFinished(best, allPurchases);
+                            }
+                        });
+            } else {
+                Log.i(TAG, "queryPurchases() -> "
+                        + "Subscriptions are not supported, skipped.");
+            }
+        });
+    }
+
+    private void onQueryPurchasesFinished(final BillingResult result,
+                                          final List<Purchase> purchases) {
+        try {
+            if (result.getResponseCode() == BillingResponseCode.OK) {
+                for (Purchase p : purchases) {
+                    storePurchase(p);
+                }
+                JSObject data = new JSObject();
+                data.put("purchases", purchasesToJson(purchases));
+                notifyListeners("setPurchases", data);
+            } else {
+                Log.d(TAG, result.getDebugMessage());
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "onQueryPurchasesFinished() -> Failed: "
+                    + e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Product details queries
+    // -------------------------------------------------------------------------
+
+    private void queryAllProductDetails(
+            List<String> inAppProductIds,
+            List<String> subsProductIds,
+            final InternalProductDetailsResponseListener listener) {
+        Log.d(TAG, "queryAllProductDetails()");
+        final ArrayList<ProductDetails> allProducts = new ArrayList<>();
+
+        final int nRequests =
+                (subsProductIds.size() > 0 ? 1 : 0)
+                        + (inAppProductIds.size() > 0 ? 1 : 0);
+        nProductDetailsQuerySuccessful = 0;
+
+        final InternalProductDetailsResponseListener queryListener =
+                (result, productDetailsList) -> {
+            mBillingClientResult = result;
+            if (result.getResponseCode() != BillingResponseCode.OK) {
+                Log.w(TAG, "queryAllProductDetails() -> Failed: "
+                        + "Unsuccessful query. " + format(result));
+                // Don't call listener on failure — let the other query finish
+            } else {
+                if (productDetailsList != null
+                        && productDetailsList.size() > 0) {
+                    for (ProductDetails product : productDetailsList) {
+                        Log.d(TAG,
+                                "queryAllProductDetails() -> ProductDetails: "
+                                        + "Title: " + product.getTitle());
+                        mProductDetails.put(product.getProductId(), product);
+                        allProducts.add(product);
+                    }
+                } else {
+                    Log.w(TAG,
+                            "queryAllProductDetails() -> Query returned nothing.");
+                }
+                nProductDetailsQuerySuccessful++;
+                if (nProductDetailsQuerySuccessful == nRequests
+                        && listener != null) {
+                    Log.d(TAG,
+                            "queryAllProductDetails() -> Calling listener.");
+                    listener.onProductDetailsResponse(result, allProducts);
+                }
+            }
+        };
+
+        List<Product> subsList = new ArrayList<>();
+        for (int i = 0; i < subsProductIds.size(); ++i) {
+            subsList.add(Product.newBuilder()
+                    .setProductId(subsProductIds.get(i))
+                    .setProductType(ProductType.SUBS)
+                    .build());
+        }
+
+        List<Product> inAppList = new ArrayList<>();
+        for (int i = 0; i < inAppProductIds.size(); ++i) {
+            inAppList.add(Product.newBuilder()
+                    .setProductId(inAppProductIds.get(i))
+                    .setProductType(ProductType.INAPP)
+                    .build());
+        }
+
+        if (subsList.size() > 0) {
+            Log.d(TAG, "queryAllProductDetails() -> Query SUBS.");
+            queryProductDetailsAsync(subsList, queryListener);
+        }
+
+        if (inAppList.size() > 0) {
+            Log.d(TAG, "queryAllProductDetails() -> Query INAPP.");
+            queryProductDetailsAsync(inAppList, queryListener);
+        }
+
+        if (inAppList.size() == 0 && subsList.size() == 0) {
+            Log.d(TAG,
+                    "queryAllProductDetails() -> Calling listener (0 requests).");
+            if (listener != null) {
+                listener.onProductDetailsResponse(getLastResult(), allProducts);
+            }
+        }
+    }
+
+    private void queryProductDetailsAsync(
+            final List<Product> productList,
+            final InternalProductDetailsResponseListener listener) {
+        Log.d(TAG, "queryProductDetailsAsync()");
+        executeServiceRequest(() -> {
+            if (getLastResponseCode() != BillingResponseCode.OK) {
+                Log.d(TAG, "queryProductDetailsAsync() -> Failed: "
+                        + format(getLastResult()));
+                listener.onProductDetailsResponse(getLastResult(), null);
+            } else {
+                Log.d(TAG, "queryProductDetailsAsync() -> Success");
+                QueryProductDetailsParams.Builder params =
+                        QueryProductDetailsParams.newBuilder();
+                params.setProductList(productList);
+                mBillingClient.queryProductDetailsAsync(params.build(),
+                        (billingResult, queryResult) -> {
+                    List<ProductDetails> productDetailsList =
+                            queryResult != null
+                                    ? queryResult.getProductDetailsList()
+                                    : null;
+                    listener.onProductDetailsResponse(
+                            billingResult, productDetailsList);
+                });
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Purchase flow
+    // -------------------------------------------------------------------------
+
+    private BillingFlowParams parseBillingFlowParams(
+            String productId,
+            JSONObject additionalData,
+            PluginCall call) throws JSONException {
+
+        // Handle "productId@offerToken" syntax
+        final String[] parts = productId.split("@", 2);
+        String offerToken = null;
+        if (parts.length == 2) {
+            productId = parts[0];
+            offerToken = parts[1];
+        }
+
+        if (offerToken == null && additionalData.has("offerToken")) {
+            offerToken = additionalData.getString("offerToken");
+        }
+
+        String oldPurchaseToken = null;
+        if (additionalData.has("oldPurchaseToken")) {
+            oldPurchaseToken = additionalData.getString("oldPurchaseToken");
+        }
+
+        final String accountId = additionalData.has("accountId")
+                ? additionalData.getString("accountId") : null;
+
+        final String profileId = additionalData.has("profileId")
+                ? additionalData.getString("profileId") : null;
+
+        final ProductDetails productDetails = mProductDetails.get(productId);
+        if (productDetails == null) {
+            Log.d(TAG, "buy() -> Failed: Product not registered: "
+                    + productId);
+            call.reject("Product not registered: " + productId);
+            return null;
+        }
+
+        BillingFlowParams.Builder params = BillingFlowParams.newBuilder();
+
+        // If not passed in additionalData, use the offer token based on the
+        // selected offer index.
+        final List<SubscriptionOfferDetails> subscriptionOfferDetails =
+                productDetails.getSubscriptionOfferDetails();
+        if (offerToken == null && subscriptionOfferDetails != null) {
+            offerToken = subscriptionOfferDetails.get(0).getOfferToken();
+        }
+
+        List<ProductDetailsParams> productDetailsParamsList = new ArrayList<>();
+        if (offerToken != null) {
+            productDetailsParamsList.add(ProductDetailsParams.newBuilder()
+                    .setProductDetails(productDetails)
+                    .setOfferToken(offerToken)
+                    .build());
+        } else {
+            productDetailsParamsList.add(ProductDetailsParams.newBuilder()
+                    .setProductDetails(productDetails)
+                    .build());
+        }
+
+        BillingFlowParams.SubscriptionUpdateParams.Builder
+                subscriptionUpdateParams =
+                BillingFlowParams.SubscriptionUpdateParams.newBuilder();
+        boolean hasSubscriptionUpdateParams = false;
+
+        params.setProductDetailsParamsList(productDetailsParamsList);
+
+        if (oldPurchaseToken != null) {
+            Log.d(TAG, "buy() -> setOldSkuPurchaseToken");
+            subscriptionUpdateParams.setOldPurchaseToken(oldPurchaseToken);
+            hasSubscriptionUpdateParams = true;
+        }
+
+        if (accountId != null) {
+            Log.d(TAG, "buy() -> setObfuscatedAccountId");
+            params.setObfuscatedAccountId(accountId);
+        }
+
+        if (profileId != null) {
+            Log.d(TAG, "buy() -> setObfuscatedProfileId");
+            params.setObfuscatedProfileId(profileId);
+        }
+
+        // Subscription replacement mode
+        final String replacementMode = additionalData.has("prorationMode")
+                ? additionalData.getString("prorationMode")
+                : additionalData.has("replacementMode")
+                ? additionalData.getString("replacementMode")
+                : null;
+        if (replacementMode != null) {
+            if ("IMMEDIATE_WITH_TIME_PRORATION".equals(replacementMode))
+                subscriptionUpdateParams.setSubscriptionReplacementMode(
+                        BillingFlowParams.SubscriptionUpdateParams
+                                .ReplacementMode.WITH_TIME_PRORATION);
+            else if ("IMMEDIATE_AND_CHARGE_PRORATED_PRICE".equals(
+                    replacementMode))
+                subscriptionUpdateParams.setSubscriptionReplacementMode(
+                        BillingFlowParams.SubscriptionUpdateParams
+                                .ReplacementMode.CHARGE_PRORATED_PRICE);
+            else if ("IMMEDIATE_WITHOUT_PRORATION".equals(replacementMode))
+                subscriptionUpdateParams.setSubscriptionReplacementMode(
+                        BillingFlowParams.SubscriptionUpdateParams
+                                .ReplacementMode.WITHOUT_PRORATION);
+            else if ("DEFERRED".equals(replacementMode))
+                subscriptionUpdateParams.setSubscriptionReplacementMode(
+                        BillingFlowParams.SubscriptionUpdateParams
+                                .ReplacementMode.DEFERRED);
+            else if ("IMMEDIATE_AND_CHARGE_FULL_PRICE".equals(replacementMode))
+                subscriptionUpdateParams.setSubscriptionReplacementMode(
+                        BillingFlowParams.SubscriptionUpdateParams
+                                .ReplacementMode.CHARGE_FULL_PRICE);
+        }
+
+        if (hasSubscriptionUpdateParams) {
+            params.setSubscriptionUpdateParams(
+                    subscriptionUpdateParams.build());
+        }
+
+        return params.build();
+    }
+
+    private void initiatePurchaseFlow(final BillingFlowParams params,
+                                      final PluginCall call) {
+        Log.d(TAG, "initiatePurchaseFlow()");
+        if (params == null) {
+            return;
+        }
+        final Activity activity = getActivity();
+        if (activity == null || activity.isFinishing()) {
+            Log.e(TAG, "Activity is null or finishing, "
+                    + "cannot launch billing flow.");
+            call.reject("Activity not available to launch billing flow.");
+            return;
+        }
+        executeServiceRequest(() -> {
+            if (getLastResponseCode() != BillingResponseCode.OK) {
+                Log.d(TAG, "initiatePurchaseFlow() -> Failed: "
+                        + "Failed to execute service request. "
+                        + format(getLastResult()));
+                call.reject("Failed to execute service request. "
+                        + format(getLastResult()));
+                return;
+            }
+            Log.d(TAG, "Attempting to launch billing flow on UI thread.");
+            activity.runOnUiThread(() -> {
+                Log.d(TAG, "launchBillingFlow happening now.");
+                BillingResult billingResult =
+                        mBillingClient.launchBillingFlow(activity, params);
+                Log.d(TAG, "launchBillingFlow immediate result: "
+                        + format(billingResult));
+                if (billingResult.getResponseCode() == BillingResponseCode.OK) {
+                    mPendingBuyCall = call;
+                } else {
+                    Log.e(TAG,
+                            "launchBillingFlow failed immediately with code: "
+                                    + format(billingResult));
+                    call.reject("launchBillingFlow failed: "
+                            + format(billingResult));
+                }
+            });
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Utility
+    // -------------------------------------------------------------------------
+
+    private List<String> jsonArrayToStringList(JSONArray arr)
+            throws JSONException {
+        List<String> list = new ArrayList<>();
+        if (arr != null) {
+            for (int i = 0; i < arr.length(); i++) {
+                list.add(arr.getString(i));
+            }
+        }
+        return list;
+    }
+}

--- a/capacitor/build/entry.mjs
+++ b/capacitor/build/entry.mjs
@@ -1,0 +1,18 @@
+// Capacitor bridge — sets CdvPurchaseCapacitor marker and registers native plugin
+export { PurchasePlugin } from '../dist/esm/index.js';
+
+// Store runtime — executes the IIFE, creates window.CdvPurchase
+import { CdvPurchase } from 'virtual:store-js';
+
+// Re-export the full namespace
+export { CdvPurchase };
+
+// Convenience named exports
+export const store = CdvPurchase.store;
+export const Store = CdvPurchase.Store;
+export const ProductType = CdvPurchase.ProductType;
+export const Platform = CdvPurchase.Platform;
+export const LogLevel = CdvPurchase.LogLevel;
+export const ErrorCode = CdvPurchase.ErrorCode;
+export const Logger = CdvPurchase.Logger;
+export const Iaptic = CdvPurchase.Iaptic;

--- a/capacitor/ios/CapacitorPluginPurchase.podspec
+++ b/capacitor/ios/CapacitorPluginPurchase.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = 'CapacitorPluginCdvPurchase'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+  s.homepage     = package['repository']['url']
+  s.author       = 'Jean-Christophe Hoelt'
+  s.source       = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.source_files = 'Sources/PurchasePlugin/**/*.{swift,h,m}'
+  s.ios.deployment_target = '13.0'
+  s.swift_version = '5.9'
+  s.dependency 'Capacitor'
+  s.frameworks   = 'StoreKit'
+end

--- a/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
+++ b/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
@@ -1,0 +1,434 @@
+import Foundation
+import Capacitor
+import StoreKit
+
+@available(iOS 15.0, *)
+private class SK2State {
+    var products: [String: Product] = [:]
+    var unfinishedTransactions: [String: Transaction] = [:]
+    var transactionObserverTask: Task<Void, Never>?
+}
+
+@objc(PurchasePlugin)
+public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
+
+    public let identifier = "PurchasePlugin"
+    public let jsName = "PurchasePlugin"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "init", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "load", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "purchase", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "finish", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "canMakePayments", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "restore", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "manageSubscriptions", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "manageBilling", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "presentCodeRedemptionSheet", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "refreshReceipts", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "loadReceipts", returnType: CAPPluginReturnPromise),
+    ]
+
+    private var _sk2State: AnyObject?
+    private var debugEnabled = false
+
+    @available(iOS 15.0, *)
+    private var sk2: SK2State {
+        if let s = _sk2State as? SK2State { return s }
+        let s = SK2State()
+        _sk2State = s
+        return s
+    }
+
+    // MARK: - Lifecycle
+
+    override public func load() {
+        if #available(iOS 15.0, *) {
+            startTransactionObserver()
+        }
+    }
+
+    deinit {
+        if #available(iOS 15.0, *) {
+            sk2.transactionObserverTask?.cancel()
+        }
+    }
+
+    @available(iOS 15.0, *)
+    private func startTransactionObserver() {
+        sk2.transactionObserverTask = Task.detached { [weak self] in
+            for await result in Transaction.updates {
+                guard let self = self else { return }
+                await self.handleTransactionUpdate(result)
+            }
+        }
+    }
+
+    @available(iOS 15.0, *)
+    private func handleTransactionUpdate(_ result: VerificationResult<Transaction>) async {
+        let jwsRepresentation = result.jwsRepresentation
+        switch result {
+        case .verified(let transaction):
+            await emitTransactionUpdate(transaction, state: "PaymentTransactionStatePurchased",
+                                        jwsRepresentation: jwsRepresentation)
+        case .unverified(let transaction, _):
+            // Emit as Purchased — let JS layer handle verification
+            await emitTransactionUpdate(transaction, state: "PaymentTransactionStatePurchased",
+                                        jwsRepresentation: jwsRepresentation)
+        }
+    }
+
+    // MARK: - Plugin Methods
+
+    @objc func `init`(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *) else {
+            call.reject("In-app purchases require iOS 15.0 or later")
+            return
+        }
+        debugEnabled = call.getBool("debug", false)
+        debugLog("init")
+
+        // Process any pending transactions
+        Task {
+            for await result in Transaction.currentEntitlements {
+                if case .verified(let transaction) = result {
+                    self.sk2.unfinishedTransactions[String(transaction.id)] = transaction
+                }
+            }
+            call.resolve()
+        }
+    }
+
+    @objc func load(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *) else {
+            call.reject("In-app purchases require iOS 15.0 or later")
+            return
+        }
+        guard let productIds = call.getArray("productIds") as? [String] else {
+            call.reject("productIds is required")
+            return
+        }
+        debugLog("load: \(productIds)")
+
+        Task {
+            do {
+                let storeProducts = try await Product.products(for: Set(productIds))
+                var validProducts: [[String: Any]] = []
+                var validIds = Set<String>()
+
+                for product in storeProducts {
+                    sk2.products[product.id] = product
+                    validProducts.append(productToDict(product))
+                    validIds.insert(product.id)
+                }
+
+                let invalidIds = productIds.filter { !validIds.contains($0) }
+
+                call.resolve([
+                    "validProducts": validProducts,
+                    "invalidProductIds": invalidIds
+                ])
+            } catch {
+                call.reject("Failed to load products: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func purchase(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *) else {
+            call.reject("In-app purchases require iOS 15.0 or later")
+            return
+        }
+        guard let productId = call.getString("productId") else {
+            call.reject("productId is required")
+            return
+        }
+        debugLog("purchase: \(productId)")
+
+        guard let product = sk2.products[productId] else {
+            call.reject("Product not loaded: \(productId)")
+            return
+        }
+
+        Task {
+            do {
+                var options: Set<Product.PurchaseOption> = []
+                if let username = call.getString("applicationUsername") {
+                    options.insert(.appAccountToken(
+                        UUID(uuidString: username) ?? UUID()))
+                }
+
+                let result = try await product.purchase(options: options)
+                switch result {
+                case .success(let verification):
+                    let jwsRepresentation = verification.jwsRepresentation
+                    switch verification {
+                    case .verified(let transaction):
+                        await emitTransactionUpdate(transaction,
+                                                    state: "PaymentTransactionStatePurchased",
+                                                    jwsRepresentation: jwsRepresentation)
+                    case .unverified(let transaction, _):
+                        // Emit as Purchased — let JS handle verification
+                        await emitTransactionUpdate(transaction,
+                                                    state: "PaymentTransactionStatePurchased",
+                                                    jwsRepresentation: jwsRepresentation)
+                    }
+                    call.resolve()
+                case .userCancelled:
+                    notifyListeners("transactionUpdated", data: [
+                        "state": "PaymentTransactionStateFailed",
+                        "errorCode": 6777006,
+                        "errorText": "Payment cancelled",
+                        "productId": productId,
+                        "transactionIdentifier": "",
+                    ])
+                    call.resolve()
+                case .pending:
+                    notifyListeners("transactionUpdated", data: [
+                        "state": "PaymentTransactionStateDeferred",
+                        "productId": productId,
+                        "transactionIdentifier": "",
+                    ])
+                    call.resolve()
+                @unknown default:
+                    call.reject("Unknown purchase result")
+                }
+            } catch {
+                call.reject("Purchase failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func finish(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *) else {
+            call.reject("In-app purchases require iOS 15.0 or later")
+            return
+        }
+        guard let transactionId = call.getString("transactionId") else {
+            call.reject("transactionId is required")
+            return
+        }
+        debugLog("finish: \(transactionId)")
+
+        Task {
+            if let transaction = sk2.unfinishedTransactions[transactionId] {
+                await transaction.finish()
+                sk2.unfinishedTransactions.removeValue(forKey: transactionId)
+                notifyListeners("transactionUpdated", data: [
+                    "state": "PaymentTransactionStateFinished",
+                    "transactionIdentifier": transactionId,
+                    "productId": transaction.productID,
+                ])
+            }
+            call.resolve()
+        }
+    }
+
+    @objc func canMakePayments(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *) else {
+            call.resolve(["canMakePayments": false])
+            return
+        }
+        call.resolve(["canMakePayments": AppStore.canMakePayments])
+    }
+
+    @objc func restore(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *) else {
+            call.reject("In-app purchases require iOS 15.0 or later")
+            return
+        }
+        debugLog("restore")
+        Task {
+            do {
+                try await AppStore.sync()
+                for await result in Transaction.currentEntitlements {
+                    if case .verified(let transaction) = result {
+                        await emitTransactionUpdate(transaction,
+                                                    state: "PaymentTransactionStateRestored",
+                                                    jwsRepresentation: result.jwsRepresentation)
+                    }
+                }
+                notifyListeners("restoreCompleted", data: [:])
+                call.resolve()
+            } catch {
+                notifyListeners("restoreFailed", data: ["errorCode": 0])
+                call.reject("Restore failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func manageSubscriptions(_ call: CAPPluginCall) {
+        guard #available(iOS 15.0, *) else {
+            call.reject("Managing subscriptions requires iOS 15.0 or later")
+            return
+        }
+        Task { @MainActor in
+            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                try? await AppStore.showManageSubscriptions(in: scene)
+            }
+            call.resolve()
+        }
+    }
+
+    @objc func manageBilling(_ call: CAPPluginCall) {
+        // No direct equivalent in SK2; resolve silently
+        call.resolve()
+    }
+
+    @objc func presentCodeRedemptionSheet(_ call: CAPPluginCall) {
+        Task { @MainActor in
+            if #available(iOS 16.0, *) {
+                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                    try? await AppStore.presentOfferCodeRedeemSheet(in: scene)
+                }
+            }
+            call.resolve()
+        }
+    }
+
+    @objc func refreshReceipts(_ call: CAPPluginCall) {
+        guard #available(iOS 16.0, *) else {
+            call.reject("refreshReceipts requires iOS 16.0 or later")
+            return
+        }
+        Task {
+            do {
+                let appTransaction = try await AppTransaction.shared
+                switch appTransaction {
+                case .verified(let transaction):
+                    call.resolve(["receipt": [
+                        "bundleIdentifier": transaction.bundleID,
+                        "appVersion": transaction.appVersion,
+                    ]])
+                case .unverified(_, _):
+                    call.reject("App transaction verification failed")
+                }
+            } catch {
+                call.reject("Failed to refresh receipts: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func loadReceipts(_ call: CAPPluginCall) {
+        // Same as refreshReceipts for SK2
+        refreshReceipts(call)
+    }
+
+    // MARK: - Helpers
+
+    @available(iOS 15.0, *)
+    private func emitTransactionUpdate(_ transaction: Transaction, state: String,
+                                       errorCode: Int? = nil, errorText: String? = nil,
+                                       jwsRepresentation: String? = nil) async {
+        let transactionId = String(transaction.id)
+        sk2.unfinishedTransactions[transactionId] = transaction
+
+        var data: [String: Any] = [
+            "state": state,
+            "transactionIdentifier": transactionId,
+            "productId": transaction.productID,
+        ]
+
+        if let errorCode = errorCode { data["errorCode"] = errorCode }
+        if let errorText = errorText { data["errorText"] = errorText }
+        // Only set originalTransactionIdentifier when it differs from the current ID
+        if transaction.originalID != transaction.id {
+            data["originalTransactionIdentifier"] = String(transaction.originalID)
+        }
+        // Use milliseconds-since-epoch to match SK2 bridge expectations
+        data["transactionDate"] = String(Int(transaction.purchaseDate.timeIntervalSince1970 * 1000))
+
+        if let expirationDate = transaction.expirationDate {
+            data["expirationDate"] = String(Int(expirationDate.timeIntervalSince1970 * 1000))
+        }
+        if let jws = jwsRepresentation {
+            data["jwsRepresentation"] = jws
+        }
+
+        notifyListeners("transactionUpdated", data: data)
+    }
+
+    @available(iOS 15.0, *)
+    private func productToDict(_ product: Product) -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": product.id,
+            "title": product.displayName,
+            "description": product.description,
+            "price": product.displayPrice,
+            "priceMicros": NSDecimalNumber(decimal: product.price)
+                .multiplying(by: 1000000).int64Value,
+            "currency": product.priceFormatStyle.currencyCode,
+            "countryCode": {
+                if #available(iOS 16.0, *) {
+                    return product.priceFormatStyle.locale.region?.identifier ?? ""
+                } else {
+                    return Locale.current.regionCode ?? ""
+                }
+            }(),
+        ]
+
+        if let subscription = product.subscription {
+            let unit = subscription.subscriptionPeriod.unit
+            let value = subscription.subscriptionPeriod.value
+            dict["billingPeriod"] = value
+            dict["billingPeriodUnit"] = periodUnitToString(unit)
+            dict["group"] = subscription.subscriptionGroupID
+
+            // Introductory offer
+            if let intro = subscription.introductoryOffer {
+                dict["introPrice"] = intro.displayPrice
+                dict["introPriceMicros"] = NSDecimalNumber(decimal: intro.price)
+                    .multiplying(by: 1000000).int64Value
+                dict["introPricePeriod"] = intro.period.value
+                dict["introPricePeriodUnit"] = periodUnitToString(intro.period.unit)
+                dict["introPricePaymentMode"] = paymentModeToString(intro.paymentMode)
+            }
+
+            // Promotional offers (discounts)
+            var discounts: [[String: Any]] = []
+            for offer in subscription.promotionalOffers {
+                discounts.append([
+                    "id": offer.id ?? "",
+                    "type": "Subscription",
+                    "price": offer.displayPrice,
+                    "priceMicros": NSDecimalNumber(decimal: offer.price)
+                        .multiplying(by: 1000000).int64Value,
+                    "period": offer.period.value,
+                    "periodUnit": periodUnitToString(offer.period.unit),
+                    "paymentMode": paymentModeToString(offer.paymentMode),
+                ])
+            }
+            if !discounts.isEmpty {
+                dict["discounts"] = discounts
+            }
+        }
+
+        return dict
+    }
+
+    @available(iOS 15.0, *)
+    private func periodUnitToString(_ unit: Product.SubscriptionPeriod.Unit) -> String {
+        switch unit {
+        case .day: return "Day"
+        case .week: return "Week"
+        case .month: return "Month"
+        case .year: return "Year"
+        @unknown default: return "Day"
+        }
+    }
+
+    @available(iOS 15.0, *)
+    private func paymentModeToString(_ mode: Product.SubscriptionOffer.PaymentMode) -> String {
+        switch mode {
+        case .payAsYouGo: return "PayAsYouGo"
+        case .payUpFront: return "PayUpFront"
+        case .freeTrial: return "FreeTrial"
+        default: return "PayAsYouGo"
+        }
+    }
+
+    private func debugLog(_ msg: String) {
+        if debugEnabled {
+            print("PurchasePlugin[debug]: \(msg)")
+        }
+    }
+}

--- a/capacitor/package-lock.json
+++ b/capacitor/package-lock.json
@@ -1,0 +1,642 @@
+{
+  "name": "capacitor-plugin-cdv-purchase",
+  "version": "13.14.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "capacitor-plugin-cdv-purchase",
+      "version": "13.14.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@capacitor/core": "^6.0.0",
+        "@rollup/plugin-node-resolve": "^16.0.0",
+        "rollup": "^4.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/capacitor/package.json
+++ b/capacitor/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "capacitor-plugin-cdv-purchase",
+  "version": "13.14.0",
+  "description": "In-App Purchases for Capacitor — iOS (StoreKit 2) and Android (Google Play Billing)",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "capacitor": {
+    "ios": { "src": "ios" },
+    "android": { "src": "android" }
+  },
+  "peerDependencies": {
+    "@capacitor/core": "^6.0.0"
+  },
+  "devDependencies": {
+    "@capacitor/core": "^6.0.0",
+    "rollup": "^4.0.0",
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "build": "tsc && rollup -c rollup.config.mjs",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist/",
+    "types/",
+    "www/",
+    "build/",
+    "android/",
+    "ios/"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/j3k0/cordova-plugin-purchase.git"
+  },
+  "keywords": [
+    "capacitor",
+    "capacitor-plugin",
+    "in-app-purchase",
+    "billing",
+    "storekit",
+    "storekit2",
+    "google-play",
+    "ios",
+    "android"
+  ]
+}

--- a/capacitor/rollup.config.mjs
+++ b/capacitor/rollup.config.mjs
@@ -1,0 +1,47 @@
+import resolve from '@rollup/plugin-node-resolve';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Rollup plugin that serves www/store.js as a virtual ES module.
+ * Appends `export { CdvPurchase }` so the IIFE-defined variable
+ * can be imported by the entry file.
+ */
+function storeJsPlugin() {
+  const VIRTUAL_ID = 'virtual:store-js';
+  const RESOLVED_ID = '\0' + VIRTUAL_ID;
+
+  return {
+    name: 'store-js',
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_ID;
+    },
+    load(id) {
+      if (id === RESOLVED_ID) {
+        let storeJs = readFileSync(join(__dirname, 'www', 'store.js'), 'utf-8');
+        // In Capacitor, window.cordova exists (Cordova shim) which causes
+        // initCDVPurchase to be called via setTimeout — too late for ES module
+        // exports. Force synchronous initialization.
+        storeJs = storeJs.replace(
+          /if \(window\.cordova\) \{[\s\S]*?setTimeout\(initCDVPurchase.*?\)[\s\S]*?\}\s*else \{\s*initCDVPurchase\(\);\s*\}/,
+          'initCDVPurchase();'
+        );
+        return storeJs + '\nexport { CdvPurchase };\n';
+      }
+    }
+  };
+}
+
+export default {
+  input: 'build/entry.mjs',
+  output: {
+    file: 'dist/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [storeJsPlugin(), resolve()],
+  external: ['@capacitor/core']
+};

--- a/capacitor/src/definitions.ts
+++ b/capacitor/src/definitions.ts
@@ -1,0 +1,92 @@
+/**
+ * Native plugin interface for Capacitor.
+ * Defines the methods exposed by the Android and iOS native plugins.
+ */
+export interface PurchasePluginPlugin {
+
+  // ===== Google Play + iOS shared =====
+
+  /** Initialize the billing client */
+  init(options?: Record<string, unknown>): Promise<void>;
+
+  /** Query available products */
+  getAvailableProducts(options: {
+    inAppSkus: string[];
+    subsSkus: string[];
+  }): Promise<{ products: unknown[] }>;
+
+  /** Query existing purchases */
+  getPurchases(): Promise<{ purchases: unknown[] }>;
+
+  /** Initiate a purchase flow */
+  buy(options: {
+    productId: string;
+    additionalData?: Record<string, unknown>;
+  }): Promise<void>;
+
+  /** Initiate a subscription flow (Android) or purchase (iOS) */
+  subscribe(options: {
+    productId: string;
+    additionalData?: Record<string, unknown>;
+  }): Promise<void>;
+
+  /** Finish/acknowledge a transaction */
+  finish(options: { transactionId: string }): Promise<void>;
+
+  /** Open subscription management UI */
+  manageSubscriptions(): Promise<void>;
+
+  /** Open billing management UI */
+  manageBilling(): Promise<void>;
+
+  // ===== Android-specific =====
+
+  /** Consume a purchase (Android) */
+  consumePurchase(options: { purchaseToken: string }): Promise<void>;
+
+  /** Acknowledge a purchase (Android) */
+  acknowledgePurchase(options: { purchaseToken: string }): Promise<void>;
+
+  /** Launch price change confirmation flow (Android) */
+  launchPriceChangeConfirmationFlow(options: {
+    productId: string;
+  }): Promise<void>;
+
+  // ===== iOS-specific =====
+
+  /** Load product details (iOS) */
+  load(options: { productIds: string[] }): Promise<{
+    validProducts: unknown[];
+    invalidProductIds: string[];
+  }>;
+
+  /** Purchase a product (iOS) */
+  purchase(options: {
+    productId: string;
+    quantity?: number;
+    applicationUsername?: string;
+    discount?: Record<string, unknown>;
+  }): Promise<void>;
+
+  /** Check if the device can make payments (iOS) */
+  canMakePayments(): Promise<{ canMakePayments: boolean }>;
+
+  /** Restore completed transactions (iOS) */
+  restore(): Promise<void>;
+
+  /** Present the code redemption sheet (iOS) */
+  presentCodeRedemptionSheet(): Promise<void>;
+
+  /** Refresh App Store receipts (iOS) */
+  refreshReceipts(): Promise<{ receipt: unknown }>;
+
+  /** Load App Store receipts (iOS) */
+  loadReceipts(): Promise<{ receipt: unknown }>;
+
+  // ===== Event listeners =====
+
+  addListener(
+    eventName: string,
+    listenerFunc: (data: any) => void
+  ): Promise<{ remove: () => Promise<void> }>;
+}

--- a/capacitor/src/index.ts
+++ b/capacitor/src/index.ts
@@ -1,0 +1,12 @@
+import { registerPlugin } from '@capacitor/core';
+import type { PurchasePluginPlugin } from './definitions';
+
+// Set the marker so the shared store.js knows Capacitor native bridges are available
+if (typeof window !== 'undefined') {
+  (window as any).CdvPurchaseCapacitor = { installed: true };
+}
+
+const PurchasePlugin = registerPlugin<PurchasePluginPlugin>('PurchasePlugin');
+
+export { PurchasePlugin };
+export type { PurchasePluginPlugin };

--- a/capacitor/tsconfig.json
+++ b/capacitor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/capacitor/types/index.d.ts
+++ b/capacitor/types/index.d.ts
@@ -1,0 +1,27 @@
+/// <reference path="../www/store.d.ts" />
+
+// Native bridge
+import type { PurchasePluginPlugin } from '../dist/esm/definitions';
+export declare const PurchasePlugin: PurchasePluginPlugin;
+export type { PurchasePluginPlugin };
+
+// Full namespace
+export declare const CdvPurchase: typeof globalThis.CdvPurchase;
+
+// Convenience value exports
+export declare const store: CdvPurchase.Store;
+export declare const Store: typeof CdvPurchase.Store;
+export declare const ProductType: typeof CdvPurchase.ProductType;
+export declare const Platform: typeof CdvPurchase.Platform;
+export declare const LogLevel: typeof CdvPurchase.LogLevel;
+export declare const ErrorCode: typeof CdvPurchase.ErrorCode;
+export declare const Logger: typeof CdvPurchase.Logger;
+export declare const Iaptic: typeof CdvPurchase.Iaptic;
+
+// Convenience type re-exports
+export type IError = CdvPurchase.IError;
+export type Product = CdvPurchase.Product;
+export type Offer = CdvPurchase.Offer;
+export type Transaction = CdvPurchase.Transaction;
+export type Receipt = CdvPurchase.Receipt;
+export type VerifiedReceipt = CdvPurchase.VerifiedReceipt;

--- a/capacitor/www/capacitor-plugin.js
+++ b/capacitor/www/capacitor-plugin.js
@@ -1,0 +1,3 @@
+window.CdvPurchaseCapacitor = {
+  installed: true,
+};

--- a/src/ts/cordova.d.ts
+++ b/src/ts/cordova.d.ts
@@ -10,7 +10,13 @@ declare interface Window {
     // Iaptic: CdvPurchase;
     CdvPurchase: CdvPurchase;
 
+    CdvPurchaseCapacitor?: {
+        installed?: boolean;
+        version?: string;
+    }
+
     Capacitor?: {
         getPlatform(): 'ios' | 'android' | 'web';
+        Plugins?: { [key: string]: any };
     }
 }

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -151,9 +151,12 @@ namespace CdvPurchase {
                 this.context = context;
                 this.log = context.log.child('AppleAppStore');
 
-                // Use SK2 if extension is installed
-                this.useSK2 = SK2Bridge.SK2NativeBridge.isAvailable();
-                if (this.useSK2) {
+                const useCapacitor = CapacitorBridge.CapacitorNativeBridge.isAvailable();
+                this.useSK2 = useCapacitor || SK2Bridge.SK2NativeBridge.isAvailable();
+                if (useCapacitor) {
+                    this.log.info('Capacitor plugin detected, using Capacitor SK2 bridge');
+                    this.bridge = new CapacitorBridge.CapacitorNativeBridge();
+                } else if (SK2Bridge.SK2NativeBridge.isAvailable()) {
                     this.log.info('StoreKit 2 extension detected, using SK2 bridge');
                     this.bridge = new SK2Bridge.SK2NativeBridge();
                 } else {

--- a/src/ts/platforms/apple-appstore/appstore-bridge-capacitor.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-capacitor.ts
@@ -1,0 +1,318 @@
+namespace CdvPurchase {
+    export namespace AppleAppStore {
+        export namespace CapacitorBridge {
+
+            let log = function log(msg: string) {
+                console.log("StoreKit[capacitor]: " + msg);
+            }
+
+            /**
+             * Capacitor implementation of the Apple AppStore bridge.
+             * Uses Capacitor.Plugins.PurchasePlugin with StoreKit 2 (iOS 15+).
+             * Follows the same pattern as SK2NativeBridge but communicates
+             * via Capacitor's plugin API instead of cordova.exec().
+             */
+            const noop = (..._args: any[]) => {};
+
+            /** Extended callbacks with SK2 fields (same as SK2BridgeCallbacks) */
+            export interface CapacitorBridgeCallbacks extends Bridge.BridgeCallbacks {
+                purchased: (transactionIdentifier: string, productId: string,
+                    originalTransactionIdentifier?: string, transactionDate?: string,
+                    discountId?: string, expirationDate?: string,
+                    jwsRepresentation?: string) => void;
+                restored: (transactionIdentifier: string, productId: string,
+                    originalTransactionIdentifier?: string, transactionDate?: string,
+                    discountId?: string, expirationDate?: string,
+                    jwsRepresentation?: string) => void;
+            }
+
+            export class CapacitorNativeBridge implements Bridge.BridgeInterface {
+
+                appStoreReceipt: ApplicationReceipt | null = null;
+                transactionsForProduct: { [productId: string]: string[] } = {};
+                readonly isSK2 = true;
+
+                private options: CapacitorBridgeCallbacks;
+                private pendingTransactionUpdates: {
+                    state: string;
+                    errorCode: number | undefined;
+                    errorText: string | undefined;
+                    transactionIdentifier: string;
+                    productId: string;
+                    transactionReceipt: string | undefined;
+                    originalTransactionIdentifier: string | undefined;
+                    transactionDate: string | undefined;
+                    discountId: string | undefined;
+                    expirationDate: string | undefined;
+                    jwsRepresentation: string | undefined;
+                }[] = [];
+                private initialized = false;
+                private needRestoreNotification = false;
+
+                constructor() {
+                    // Initialize all callbacks to noop (matching SK2NativeBridge pattern)
+                    this.options = {
+                        error: noop, ready: noop,
+                        purchased: noop, purchaseEnqueued: noop,
+                        purchasing: noop, purchaseFailed: noop,
+                        deferred: noop, finished: noop,
+                        restored: noop, receiptsRefreshed: noop,
+                        restoreCompleted: noop, restoreFailed: noop,
+                    } as CapacitorBridgeCallbacks;
+                }
+
+                /** Check if the Capacitor purchase plugin is available */
+                static isAvailable(): boolean {
+                    const marker = window.CdvPurchaseCapacitor;
+                    return !!(marker && marker.installed);
+                }
+
+                private get plugin(): any {
+                    return window.Capacitor?.Plugins?.PurchasePlugin;
+                }
+
+                init(options: Partial<Bridge.BridgeOptions>,
+                     success: () => void,
+                     error: (code: ErrorCode, message: string) => void): void {
+
+                    if (options.log) log = options.log;
+                    // Merge provided options over defaults (noop callbacks)
+                    this.options = { ...this.options, ...options } as CapacitorBridgeCallbacks;
+
+                    const plugin = this.plugin;
+                    if (!plugin) {
+                        error(ErrorCode.SETUP, 'Capacitor PurchasePlugin not available');
+                        return;
+                    }
+
+                    // Listen for transaction updates from native
+                    plugin.addListener('transactionUpdated', (data: any) => {
+                        this.transactionUpdated(
+                            data.state,
+                            data.errorCode,
+                            data.errorText,
+                            data.transactionIdentifier,
+                            data.productId,
+                            data.transactionReceipt,
+                            data.originalTransactionIdentifier,
+                            data.transactionDate,
+                            data.discountId,
+                            data.expirationDate,
+                            data.jwsRepresentation,
+                        );
+                    });
+
+                    plugin.addListener('restoreCompleted', () => {
+                        this.restoreCompletedTransactionsFinished();
+                    });
+
+                    plugin.addListener('restoreFailed', (data: any) => {
+                        this.restoreCompletedTransactionsFailed(data.errorCode);
+                    });
+
+                    // Initialize the native plugin
+                    const initOpts: Record<string, unknown> = {};
+                    if (options.autoFinish !== undefined) initOpts.autoFinish = options.autoFinish;
+                    if (options.debug !== undefined) initOpts.debug = options.debug;
+
+                    plugin.init(initOpts)
+                        .then(() => {
+                            this.initialized = true;
+                            // Flush pending transaction updates
+                            const pending = this.pendingTransactionUpdates;
+                            this.pendingTransactionUpdates = [];
+                            for (const args of pending) {
+                                this.transactionUpdated(
+                                    args.state, args.errorCode, args.errorText,
+                                    args.transactionIdentifier, args.productId,
+                                    args.transactionReceipt, args.originalTransactionIdentifier,
+                                    args.transactionDate, args.discountId,
+                                    args.expirationDate, args.jwsRepresentation);
+                            }
+                            if (this.options.ready) this.options.ready();
+                            success();
+                        })
+                        .catch((err: any) => {
+                            error(ErrorCode.SETUP, err?.message || 'init failed');
+                        });
+                }
+
+                load(productIds: string[],
+                     success: (validProducts: Bridge.ValidProduct[], invalidProductIds: string[]) => void,
+                     error: (code: ErrorCode, message: string) => void): void {
+                    this.plugin.load({ productIds })
+                        .then((result: any) => success(result.validProducts, result.invalidProductIds))
+                        .catch((err: any) => error(ErrorCode.LOAD, err?.message || 'load failed'));
+                }
+
+                purchase(productId: string, quantity: number,
+                         applicationUsername: string | undefined,
+                         discount: PaymentDiscount | undefined,
+                         success: () => void, error: () => void): void {
+                    this.plugin.purchase({ productId, quantity, applicationUsername, discount })
+                        .then(() => success())
+                        .catch(() => error());
+                }
+
+                finish(transactionId: string,
+                       success: () => void,
+                       error: (msg: string) => void): void {
+                    this.plugin.finish({ transactionId })
+                        .then(() => success())
+                        .catch((err: any) => error(err?.message || 'finish failed'));
+                }
+
+                canMakePayments(success: () => void,
+                                error: (message: string) => void): void {
+                    this.plugin.canMakePayments()
+                        .then((result: any) => {
+                            if (result.canMakePayments) success();
+                            else error('cannot make payments');
+                        })
+                        .catch((err: any) => error(err?.message || 'canMakePayments failed'));
+                }
+
+                restore(callback?: Callback<any>): void {
+                    this.needRestoreNotification = true;
+                    this.plugin.restore()
+                        .then(() => { if (callback) callback(true); })
+                        .catch(() => { if (callback) callback(false); });
+                }
+
+                manageSubscriptions(callback?: Callback<any>): void {
+                    this.plugin.manageSubscriptions()
+                        .then(() => { if (callback) callback(true); })
+                        .catch(() => { if (callback) callback(false); });
+                }
+
+                manageBilling(callback?: Callback<any>): void {
+                    this.plugin.manageBilling()
+                        .then(() => { if (callback) callback(true); })
+                        .catch(() => { if (callback) callback(false); });
+                }
+
+                presentCodeRedemptionSheet(callback?: Callback<any>): void {
+                    this.plugin.presentCodeRedemptionSheet()
+                        .then(() => { if (callback) callback(true); })
+                        .catch(() => { if (callback) callback(false); });
+                }
+
+                refreshReceipts(successCb: (receipt: ApplicationReceipt) => void,
+                                errorCb: (code: ErrorCode, message: string) => void): void {
+                    this.plugin.refreshReceipts()
+                        .then((result: any) => {
+                            this.appStoreReceipt = result.receipt;
+                            if (this.options.receiptsRefreshed) {
+                                this.options.receiptsRefreshed(result.receipt);
+                            }
+                            successCb(result.receipt);
+                        })
+                        .catch((err: any) => errorCb(ErrorCode.REFRESH_RECEIPTS, err?.message || 'refreshReceipts failed'));
+                }
+
+                loadReceipts(callback: (receipt: ApplicationReceipt) => void,
+                             errorCb: (code: ErrorCode, message: string) => void): void {
+                    this.plugin.loadReceipts()
+                        .then((result: any) => {
+                            this.appStoreReceipt = result.receipt;
+                            callback(result.receipt);
+                        })
+                        .catch((err: any) => errorCb(ErrorCode.LOAD, err?.message || 'loadReceipts failed'));
+                }
+
+                // Called when the native side sends a transaction update
+                private transactionUpdated(
+                    state: string,
+                    errorCode: number | undefined,
+                    errorText: string | undefined,
+                    transactionIdentifier: string,
+                    productId: string,
+                    transactionReceipt: string | undefined,
+                    originalTransactionIdentifier: string | undefined,
+                    transactionDate: string | undefined,
+                    discountId: string | undefined,
+                    expirationDate?: string,
+                    jwsRepresentation?: string,
+                ): void {
+                    if (!this.initialized) {
+                        this.pendingTransactionUpdates.push({
+                            state, errorCode, errorText, transactionIdentifier,
+                            productId, transactionReceipt, originalTransactionIdentifier,
+                            transactionDate, discountId, expirationDate, jwsRepresentation,
+                        });
+                        return;
+                    }
+
+                    // Track transaction for product
+                    if (!this.transactionsForProduct[productId]) {
+                        this.transactionsForProduct[productId] = [];
+                    }
+                    if (transactionIdentifier &&
+                        this.transactionsForProduct[productId].indexOf(transactionIdentifier) < 0) {
+                        this.transactionsForProduct[productId].push(transactionIdentifier);
+                    }
+
+                    switch (state) {
+                        case 'PaymentTransactionStatePurchasing':
+                            if (this.options.purchasing) {
+                                this.options.purchasing(productId);
+                            }
+                            break;
+                        case 'PaymentTransactionStatePurchased':
+                            if (this.options.purchased) {
+                                this.options.purchased(
+                                    transactionIdentifier, productId,
+                                    originalTransactionIdentifier,
+                                    transactionDate, discountId,
+                                    expirationDate, jwsRepresentation);
+                            }
+                            break;
+                        case 'PaymentTransactionStateFailed':
+                            if (this.options.purchaseFailed) {
+                                this.options.purchaseFailed(
+                                    productId, errorCode || 0, errorText || 'Unknown error');
+                            }
+                            if (this.options.error) {
+                                this.options.error(errorCode || 0,
+                                    errorText || 'Unknown error', { productId });
+                            }
+                            break;
+                        case 'PaymentTransactionStateRestored':
+                            if (this.options.restored) {
+                                this.options.restored(
+                                    transactionIdentifier, productId,
+                                    originalTransactionIdentifier,
+                                    transactionDate, discountId,
+                                    expirationDate, jwsRepresentation);
+                            }
+                            break;
+                        case 'PaymentTransactionStateDeferred':
+                            if (this.options.deferred) {
+                                this.options.deferred(productId);
+                            }
+                            break;
+                        case 'PaymentTransactionStateFinished':
+                            if (this.options.finished) {
+                                this.options.finished(transactionIdentifier, productId);
+                            }
+                            break;
+                    }
+                }
+
+                private restoreCompletedTransactionsFinished(): void {
+                    if (!this.needRestoreNotification) return;
+                    this.needRestoreNotification = false;
+                    if (this.options.restoreCompleted) {
+                        this.options.restoreCompleted();
+                    }
+                }
+
+                private restoreCompletedTransactionsFailed(errorCode: number): void {
+                    if (this.options.restoreFailed) {
+                        this.options.restoreFailed(errorCode);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -122,7 +122,9 @@ namespace CdvPurchase {
             private _receipts: Receipt[] = [];
 
             /** The GooglePlay bridge */
-            bridge = new Bridge.Bridge();
+            bridge: Bridge.BridgeInterface = Bridge.CapacitorBridge.isAvailable()
+                ? new Bridge.CapacitorBridge()
+                : new Bridge.Bridge();
 
             /** Prevent double initialization */
             initialized = false;

--- a/src/ts/platforms/google-play/googleplay-bridge-capacitor.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge-capacitor.ts
@@ -1,0 +1,185 @@
+namespace CdvPurchase {
+    export namespace GooglePlay {
+        export namespace Bridge {
+
+            let log = function log(msg: string) {
+                console.log("InAppBilling[capacitor]: " + msg);
+            }
+
+            /**
+             * Capacitor implementation of the Google Play bridge.
+             * Uses Capacitor.Plugins.PurchasePlugin instead of cordova.exec().
+             */
+            export class CapacitorBridge implements BridgeInterface {
+
+                options: Options = {};
+
+                /** Check if the Capacitor purchase plugin is available */
+                static isAvailable(): boolean {
+                    const marker = window.CdvPurchaseCapacitor;
+                    return !!(marker && marker.installed);
+                }
+
+                private get plugin(): any {
+                    return window.Capacitor?.Plugins?.PurchasePlugin;
+                }
+
+                init(success: () => void, fail: ErrorCallback, options: Options) {
+                    if (!options) options = {};
+                    if (options.log) log = options.log;
+
+                    this.options = {
+                        showLog: options.showLog !== false,
+                        onPurchaseConsumed: options.onPurchaseConsumed,
+                        onPurchasesUpdated: options.onPurchasesUpdated,
+                        onSetPurchases: options.onSetPurchases,
+                        onPriceChangeConfirmationResult: options.onPriceChangeConfirmationResult,
+                    };
+
+                    if (this.options.showLog) {
+                        log('init');
+                    }
+
+                    // Register event listeners
+                    const plugin = this.plugin;
+                    if (!plugin) {
+                        fail('Capacitor PurchasePlugin not available');
+                        return;
+                    }
+
+                    plugin.addListener('setPurchases', (data: any) => {
+                        if (this.options.onSetPurchases) {
+                            this.options.onSetPurchases(data.purchases);
+                        }
+                    });
+
+                    plugin.addListener('purchasesUpdated', (data: any) => {
+                        if (this.options.onPurchasesUpdated) {
+                            this.options.onPurchasesUpdated(data.purchases);
+                        }
+                    });
+
+                    plugin.addListener('purchaseConsumed', (data: any) => {
+                        if (this.options.onPurchaseConsumed) {
+                            this.options.onPurchaseConsumed(data.purchase);
+                        }
+                    });
+
+                    plugin.addListener('priceChangeConfirmationResult', (data: any) => {
+                        if (this.options.onPriceChangeConfirmationResult) {
+                            this.options.onPriceChangeConfirmationResult(data.result);
+                        }
+                    });
+
+                    // Initialize the native billing client
+                    plugin.init()
+                        .then(() => success())
+                        .catch((err: any) => fail(err?.message || 'init failed', err?.code));
+                }
+
+                load(success: () => void, fail: ErrorCallback,
+                     skus: string[], inAppSkus: string[], subsSkus: string[]) {
+                    if (this.options.showLog) {
+                        log('load ' + JSON.stringify(skus));
+                    }
+                    // Note: The adapter never calls load() directly — it uses
+                    // getAvailableProducts(). This implementation is for interface
+                    // completeness and passes all parameters through.
+                    this.plugin.getAvailableProducts({ inAppSkus, subsSkus })
+                        .then(() => success())
+                        .catch((err: any) => fail(err?.message || 'load failed', err?.code));
+                }
+
+                getPurchases(success: () => void, fail: ErrorCallback) {
+                    if (this.options.showLog) {
+                        log('getPurchases()');
+                    }
+                    this.plugin.getPurchases()
+                        .then(() => success())
+                        .catch((err: any) => fail(err?.message || 'getPurchases failed', err?.code));
+                }
+
+                buy(success: () => void, fail: ErrorCallback,
+                    productId: string, additionalData: CdvPurchase.AdditionalData) {
+                    if (this.options.showLog) {
+                        log('buy()');
+                    }
+                    this.plugin.buy({
+                        productId,
+                        additionalData: extendAdditionalData(additionalData),
+                    })
+                        .then(() => success())
+                        .catch((err: any) => fail(err?.message || 'buy failed', err?.code));
+                }
+
+                subscribe(success: () => void, fail: ErrorCallback,
+                          productId: string, additionalData: CdvPurchase.AdditionalData) {
+                    if (this.options.showLog) {
+                        log('subscribe()');
+                    }
+                    this.plugin.subscribe({
+                        productId,
+                        additionalData: extendAdditionalData(additionalData),
+                    })
+                        .then(() => success())
+                        .catch((err: any) => fail(err?.message || 'subscribe failed', err?.code));
+                }
+
+                consumePurchase(success: () => void, fail: ErrorCallback,
+                                purchaseToken: string) {
+                    if (this.options.showLog) {
+                        log('consumePurchase()');
+                    }
+                    this.plugin.consumePurchase({ purchaseToken })
+                        .then(() => success())
+                        .catch((err: any) => fail(err?.message || 'consumePurchase failed', err?.code));
+                }
+
+                acknowledgePurchase(success: () => void, fail: ErrorCallback,
+                                    purchaseToken: string) {
+                    if (this.options.showLog) {
+                        log('acknowledgePurchase()');
+                    }
+                    this.plugin.acknowledgePurchase({ purchaseToken })
+                        .then(() => success())
+                        .catch((err: any) => fail(err?.message || 'acknowledgePurchase failed', err?.code));
+                }
+
+                getAvailableProducts(inAppSkus: string[], subsSkus: string[],
+                                     success: (validProducts: (InAppProduct | Subscription)[]) => void,
+                                     fail: ErrorCallback) {
+                    if (this.options.showLog) {
+                        log('getAvailableProducts()');
+                    }
+                    this.plugin.getAvailableProducts({ inAppSkus, subsSkus })
+                        .then((result: any) => success(result.products))
+                        .catch((err: any) => fail(err?.message || 'getAvailableProducts failed', err?.code));
+                }
+
+                manageSubscriptions() {
+                    this.plugin.manageSubscriptions();
+                }
+
+                manageBilling() {
+                    this.plugin.manageBilling();
+                }
+
+                launchPriceChangeConfirmationFlow(productId: string) {
+                    this.plugin.launchPriceChangeConfirmationFlow({ productId });
+                }
+            }
+
+            function ensureObject<T extends Object>(obj: any): T {
+                return !!obj && obj.constructor === Object ? obj : {} as T;
+            }
+
+            function extendAdditionalData(ad?: CdvPurchase.AdditionalData): AdditionalData {
+                const additionalData: AdditionalData = ensureObject(ad?.googlePlay);
+                if (!additionalData.accountId && ad?.applicationUsername) {
+                    additionalData.accountId = Utils.md5(ad.applicationUsername);
+                }
+                return additionalData;
+            }
+        }
+    }
+}

--- a/src/ts/platforms/google-play/googleplay-bridge-interface.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge-interface.ts
@@ -1,0 +1,45 @@
+namespace CdvPurchase {
+    export namespace GooglePlay {
+        export namespace Bridge {
+
+            /**
+             * Shared interface for Google Play bridge implementations.
+             * Both Cordova and Capacitor bridges implement this interface.
+             * The adapter programs against this interface, not a concrete class.
+             */
+            export interface BridgeInterface {
+
+                options: Options;
+
+                init(success: () => void, fail: ErrorCallback, options: Options): void;
+
+                load(success: () => void, fail: ErrorCallback,
+                     skus: string[], inAppSkus: string[], subsSkus: string[]): void;
+
+                getPurchases(success: () => void, fail: ErrorCallback): void;
+
+                buy(success: () => void, fail: ErrorCallback,
+                    productId: string, additionalData: CdvPurchase.AdditionalData): void;
+
+                subscribe(success: () => void, fail: ErrorCallback,
+                          productId: string, additionalData: CdvPurchase.AdditionalData): void;
+
+                consumePurchase(success: () => void, fail: ErrorCallback,
+                                purchaseToken: string): void;
+
+                acknowledgePurchase(success: () => void, fail: ErrorCallback,
+                                    purchaseToken: string): void;
+
+                getAvailableProducts(inAppSkus: string[], subsSkus: string[],
+                                     success: (validProducts: (InAppProduct | Subscription)[]) => void,
+                                     fail: ErrorCallback): void;
+
+                manageSubscriptions(): void;
+
+                manageBilling(): void;
+
+                launchPriceChangeConfirmationFlow(productId: string): void;
+            }
+        }
+    }
+}

--- a/src/ts/platforms/google-play/googleplay-bridge.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge.ts
@@ -189,7 +189,7 @@ namespace CdvPurchase {
                 data: { purchase: Purchase; }
             };
 
-            export class Bridge {
+            export class Bridge implements BridgeInterface {
 
                 options: Options = {};
 


### PR DESCRIPTION
## Summary

- Add `capacitor-plugin-purchase` as a dual-published package from the same repo, sharing the `CdvPurchase.Store` API and adapter layer with `cordova-plugin-purchase`
- Capacitor native bridges for Android (Google Play BillingClient 8.3.0) and iOS (StoreKit 2, iOS 15+)
- Runtime bridge selection via marker detection (`window.CdvPurchaseCapacitor`) — same pattern as the existing SK2 extension
- Zero breaking changes for existing Cordova or Capacitor-via-compat-shim users

### What's included

**Shared TypeScript layer:**
- Extracted `GooglePlayBridgeInterface` for Cordova/Capacitor bridge polymorphism
- `CapacitorBridge` (Google Play) and `CapacitorNativeBridge` (Apple AppStore) implementations
- Runtime bridge selection in both adapters
- Marker infrastructure for Capacitor plugin detection

**Capacitor package (`capacitor/`):**
- Plugin registration (`registerPlugin`) and TypeScript definitions
- Android native plugin (Java, BillingClient 8.3.0) — full purchase flow, product queries, consume/acknowledge, subscription management
- iOS native plugin (Swift, StoreKit 2) — full purchase flow, product queries, restore, subscription management, offer codes
- Package config, podspec, README with migration guide

**Build & CI:**
- `make capacitor-package` / `make check-versions` targets
- GitHub Actions workflows for Capacitor Android and iOS builds

**Cleanup:**
- Removed abandoned `CapacitorPurchasePlugin.java` prototype

### Migration path

Existing Capacitor users with `cordova-plugin-purchase`:
1. `npm install capacitor-plugin-purchase && npx cap sync`
2. Code unchanged — same `CdvPurchase.Store` API
3. Native Capacitor bridges activate automatically
4. Optionally remove `cordova-plugin-purchase`

## Test plan

- [x] `make build` passes (TypeScript compile + 12/12 unit tests + Java lint)
- [x] `make check-versions` — all versions match (13.14.0)
- [x] `make capacitor-package` — assembles successfully
- [x] `plugin.xml` unchanged (no Cordova regression)
- [ ] CI: Capacitor Android build passes
- [ ] CI: Capacitor iOS build passes
- [ ] Manual device testing (separate effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)