### PR TITLE
Fix getOffer() returning discount instead of default offer on iOS

### DIFF
--- a/src/ts/platforms/apple-appstore/appstore-product.ts
+++ b/src/ts/platforms/apple-appstore/appstore-product.ts
@@ -109,6 +109,14 @@ namespace CdvPurchase {
           }, decorator));
         }
 
+        // Ensure the default offer is always first so that getOffer()
+        // without arguments returns it instead of a discount offer.
+        const defaultIndex = this.offers.findIndex(o => o.id === DEFAULT_OFFER_ID);
+        if (defaultIndex > 0) {
+          const [defaultOffer] = this.offers.splice(defaultIndex, 1);
+          this.offers.unshift(defaultOffer);
+        }
+
         function hasIntroductoryOffer(product: SKProduct) {
           return product.offers.filter(offer => {
             const skOffer = offer as SKOffer;

--- a/www/store.js
+++ b/www/store.js
@@ -4335,6 +4335,13 @@ var CdvPurchase;
                         offerType: 'Default',
                     }, decorator));
                 }
+                // Ensure the default offer is always first so that getOffer()
+                // without arguments returns it instead of a discount offer.
+                const defaultIndex = this.offers.findIndex(o => o.id === AppleAppStore.DEFAULT_OFFER_ID);
+                if (defaultIndex > 0) {
+                    const [defaultOffer] = this.offers.splice(defaultIndex, 1);
+                    this.offers.unshift(defaultOffer);
+                }
                 function hasIntroductoryOffer(product) {
                     return product.offers.filter(offer => {
                         const skOffer = offer;


### PR DESCRIPTION
## Summary

Fixes #1600.

On iOS, when a product has discount offers, `SKProduct.refresh()` adds discount offers before the default offer (id `$`). This means `product.getOffer()` (no arguments) returns `this.offers[0]`, which is a discount offer instead of the base offer. Ordering a discount offer without `additionalData.appStore.discount` then fails with "Missing additionalData.appStore.discount when ordering a discount offer".

## Fix

After all offers are built in `SKProduct.refresh()`, reorder the offers array so the default offer (`DEFAULT_OFFER_ID`) is always at index 0. This ensures `getOffer()` without arguments returns the base offer, matching the documented behavior.

## Test plan

- Verify `getOffer()` with no arguments returns the default offer (`$`) on iOS products with discount offers
- Verify `getOffer('specific-id')` still returns the correct discount offer
- Verify products without discount offers are unaffected