### PR TITLE
Fix iOS transaction observer and receipt loading at startup

### DIFF
--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -205,9 +205,16 @@ namespace CdvPurchase {
                 return new Promise(resolve => {
                     this.initializeAppReceipt(() => {
                         if (!this._receipt) {
-                            // this should not happen
-                            this.log.warn('Failed to load the application receipt, cannot proceed with handling the purchase');
-                            return;
+                            // Receipt failed to load — create a minimal receipt so the
+                            // transaction can still be tracked and finished.  Without this
+                            // fallback the Promise would never resolve, leaving the native
+                            // transaction unfinished (causing the purchase dialog to loop on
+                            // iOS — see #1568).
+                            this.log.warn('Application receipt unavailable, creating a fallback receipt to avoid blocking transactions');
+                            this._receipt = new SKApplicationReceipt(
+                                { appStoreReceipt: '', bundleIdentifier: '',
+                                  bundleShortVersion: '', bundleNumericVersion: 0, bundleSignature: '' },
+                                false, this.context.apiDecorators);
                         }
                         const existing = this._receipt?.transactions.find(t => t.transactionId === transactionId) as SKTransaction | undefined;
                         if (existing) {
@@ -391,19 +398,24 @@ namespace CdvPurchase {
 
             supportsParallelLoading = true;
 
-            loadReceipts(): Promise<Receipt[]> {
+            async loadReceipts(): Promise<Receipt[]> {
+                // Wait for native pending transactions to be processed before
+                // initializing the receipt.  Previously used a fixed 300ms delay
+                // which was unreliable and could miss transactions that arrived
+                // from the native queue (see #1529).
+                if (this.bridge.pendingTransactionsReady) {
+                    await this.bridge.pendingTransactionsReady;
+                }
                 return new Promise((resolve) => {
-                    setTimeout(() => {
-                        this.initializeAppReceipt(() => {
-                            this.receiptsUpdated.call();
-                            if (this._receipt) {
-                                resolve([this._receipt, this.pseudoReceipt]);
-                            }
-                            else {
-                                resolve([this.pseudoReceipt]);
-                            }
-                        });
-                    }, 300);
+                    this.initializeAppReceipt(() => {
+                        this.receiptsUpdated.call();
+                        if (this._receipt) {
+                            resolve([this._receipt, this.pseudoReceipt]);
+                        }
+                        else {
+                            resolve([this.pseudoReceipt]);
+                        }
+                    });
                 });
             }
 
@@ -466,6 +478,7 @@ namespace CdvPurchase {
                     return;
                 }
                 this._receipt = new SKApplicationReceipt(nativeData, this.needAppReceipt, this.context.apiDecorators);
+                this._appStoreReceiptLoading = false;
                 callCallbacks(undefined);
             }
 

--- a/src/ts/platforms/apple-appstore/appstore-bridge-interface.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-interface.ts
@@ -20,6 +20,8 @@ namespace CdvPurchase {
                 transactionsForProduct: { [productId: string]: string[] };
                 /** Whether this bridge uses StoreKit 2 */
                 readonly isSK2?: boolean;
+                /** Resolves when pending transactions from the native queue have been processed */
+                pendingTransactionsReady?: Promise<void>;
 
                 init(options: Partial<BridgeOptions>, success: () => void,
                      error: (code: ErrorCode, message: string) => void): void;

--- a/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge-sk2.ts
@@ -42,6 +42,8 @@ namespace CdvPurchase {
                 appStoreReceipt?: AppleAppStore.ApplicationReceipt | null;
                 private registeredProducts: string[] = [];
                 private needRestoreNotification = false;
+                pendingTransactionsReady?: Promise<void>;
+                private _pendingTransactionsResolve?: () => void;
                 private pendingUpdates: {
                     state: Bridge.TransactionState;
                     errorCode: ErrorCode | undefined;
@@ -119,6 +121,9 @@ namespace CdvPurchase {
                         protectCall(this.options.ready, 'options.ready');
                         protectCall(success, 'init.success');
                         this.initialized = true;
+                        this.pendingTransactionsReady = new Promise<void>(resolve => {
+                            this._pendingTransactionsResolve = resolve;
+                        });
                         setTimeout(() => this.processPendingTransactions(), 50);
                     };
 
@@ -134,6 +139,10 @@ namespace CdvPurchase {
                     log('processing pending transactions');
                     exec('processPendingTransactions', [], () => {
                         this.finalizeTransactionUpdates();
+                        if (this._pendingTransactionsResolve) {
+                            this._pendingTransactionsResolve();
+                            this._pendingTransactionsResolve = undefined;
+                        }
                     }, undefined);
                 }
 

--- a/src/ts/platforms/apple-appstore/appstore-bridge.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge.ts
@@ -243,6 +243,10 @@ namespace CdvPurchase {
                 /** True if "restoreCompleted" or "restoreFailed" should be called when restore is done */
                 private needRestoreNotification = false;
 
+                /** Resolves when pending transactions from the native queue have been processed */
+                pendingTransactionsReady?: Promise<void>;
+                private _pendingTransactionsResolve?: () => void;
+
                 /*
                 private eventQueue: {
                     state: TransactionState;
@@ -342,6 +346,9 @@ namespace CdvPurchase {
                         protectCall(this.options.ready, 'options.ready');
                         protectCall(success, 'init.success');
                         this.initialized = true;
+                        this.pendingTransactionsReady = new Promise<void>(resolve => {
+                            this._pendingTransactionsResolve = resolve;
+                        });
                         setTimeout(() => this.processPendingTransactions(), 50);
                     };
 
@@ -358,6 +365,10 @@ namespace CdvPurchase {
                     log('processing pending transactions');
                     exec('processPendingTransactions', [], () => {
                         this.finalizeTransactionUpdates();
+                        if (this._pendingTransactionsResolve) {
+                            this._pendingTransactionsResolve();
+                            this._pendingTransactionsResolve = undefined;
+                        }
                     }, undefined);
                 }
 

--- a/www/store.d.ts
+++ b/www/store.d.ts
@@ -2652,6 +2652,8 @@ declare namespace CdvPurchase {
                 };
                 /** Whether this bridge uses StoreKit 2 */
                 readonly isSK2?: boolean;
+                /** Resolves when pending transactions from the native queue have been processed */
+                pendingTransactionsReady?: Promise<void>;
                 init(options: Partial<BridgeOptions>, success: () => void, error: (code: ErrorCode, message: string) => void): void;
                 load(productIds: string[], success: (validProducts: ValidProduct[], invalidProductIds: string[]) => void, error: (code: ErrorCode, message: string) => void): void;
                 purchase(productId: string, quantity: number, applicationUsername: string | undefined, discount: PaymentDiscount | undefined, success: () => void, error: () => void): void;
@@ -2684,6 +2686,8 @@ declare namespace CdvPurchase {
                 appStoreReceipt?: AppleAppStore.ApplicationReceipt | null;
                 private registeredProducts;
                 private needRestoreNotification;
+                pendingTransactionsReady?: Promise<void>;
+                private _pendingTransactionsResolve?;
                 private pendingUpdates;
                 /** True when this bridge is active (SK2 extension installed + iOS 15+) */
                 readonly isSK2 = true;
@@ -2874,6 +2878,9 @@ declare namespace CdvPurchase {
                 private registeredProducts;
                 /** True if "restoreCompleted" or "restoreFailed" should be called when restore is done */
                 private needRestoreNotification;
+                /** Resolves when pending transactions from the native queue have been processed */
+                pendingTransactionsReady?: Promise<void>;
+                private _pendingTransactionsResolve?;
                 /** List of transaction updates to process */
                 private pendingUpdates;
                 constructor();

--- a/www/store.js
+++ b/www/store.js
@@ -2954,9 +2954,14 @@ var CdvPurchase;
                         this.initializeAppReceipt(() => {
                             var _a;
                             if (!this._receipt) {
-                                // this should not happen
-                                this.log.warn('Failed to load the application receipt, cannot proceed with handling the purchase');
-                                return;
+                                // Receipt failed to load — create a minimal receipt so the
+                                // transaction can still be tracked and finished.  Without this
+                                // fallback the Promise would never resolve, leaving the native
+                                // transaction unfinished (causing the purchase dialog to loop on
+                                // iOS — see #1568).
+                                this.log.warn('Application receipt unavailable, creating a fallback receipt to avoid blocking transactions');
+                                this._receipt = new AppleAppStore.SKApplicationReceipt({ appStoreReceipt: '', bundleIdentifier: '',
+                                    bundleShortVersion: '', bundleNumericVersion: 0, bundleSignature: '' }, false, this.context.apiDecorators);
                             }
                             const existing = (_a = this._receipt) === null || _a === void 0 ? void 0 : _a.transactions.find(t => t.transactionId === transactionId);
                             if (existing) {
@@ -3117,8 +3122,15 @@ var CdvPurchase;
                 });
             }
             loadReceipts() {
-                return new Promise((resolve) => {
-                    setTimeout(() => {
+                return __awaiter(this, void 0, void 0, function* () {
+                    // Wait for native pending transactions to be processed before
+                    // initializing the receipt.  Previously used a fixed 300ms delay
+                    // which was unreliable and could miss transactions that arrived
+                    // from the native queue (see #1529).
+                    if (this.bridge.pendingTransactionsReady) {
+                        yield this.bridge.pendingTransactionsReady;
+                    }
+                    return new Promise((resolve) => {
                         this.initializeAppReceipt(() => {
                             this.receiptsUpdated.call();
                             if (this._receipt) {
@@ -3128,7 +3140,7 @@ var CdvPurchase;
                                 resolve([this.pseudoReceipt]);
                             }
                         });
-                    }, 300);
+                    });
                 });
             }
             canMakePayments() {
@@ -3184,6 +3196,7 @@ var CdvPurchase;
                         return;
                     }
                     this._receipt = new AppleAppStore.SKApplicationReceipt(nativeData, this.needAppReceipt, this.context.apiDecorators);
+                    this._appStoreReceiptLoading = false;
                     callCallbacks(undefined);
                 });
             }
@@ -3641,6 +3654,9 @@ var CdvPurchase;
                         protectCall(this.options.ready, 'options.ready');
                         protectCall(success, 'init.success');
                         this.initialized = true;
+                        this.pendingTransactionsReady = new Promise(resolve => {
+                            this._pendingTransactionsResolve = resolve;
+                        });
                         setTimeout(() => this.processPendingTransactions(), 50);
                     };
                     const setupFailed = (err) => {
@@ -3653,6 +3669,10 @@ var CdvPurchase;
                     log('processing pending transactions');
                     exec('processPendingTransactions', [], () => {
                         this.finalizeTransactionUpdates();
+                        if (this._pendingTransactionsResolve) {
+                            this._pendingTransactionsResolve();
+                            this._pendingTransactionsResolve = undefined;
+                        }
                     }, undefined);
                 }
                 purchase(productId, quantity, applicationUsername, discount, success, error) {
@@ -3947,6 +3967,9 @@ var CdvPurchase;
                         protectCall(this.options.ready, 'options.ready');
                         protectCall(success, 'init.success');
                         this.initialized = true;
+                        this.pendingTransactionsReady = new Promise(resolve => {
+                            this._pendingTransactionsResolve = resolve;
+                        });
                         setTimeout(() => this.processPendingTransactions(), 50);
                     };
                     const setupFailed = (err) => {
@@ -3960,6 +3983,10 @@ var CdvPurchase;
                     log('processing pending transactions');
                     exec('processPendingTransactions', [], () => {
                         this.finalizeTransactionUpdates();
+                        if (this._pendingTransactionsResolve) {
+                            this._pendingTransactionsResolve();
+                            this._pendingTransactionsResolve = undefined;
+                        }
                     }, undefined);
                 }
                 /**


### PR DESCRIPTION
## Summary

Fixes three related iOS issues where transactions are not properly processed:

- **#1568**: `approved` callback never fires after purchase — the `upsertTransaction` Promise hangs forever when `initializeAppReceipt` fails to load the receipt (e.g. missing/empty `appStoreReceipt`). The native transaction is never finished, causing the sandbox purchase dialog to loop.
- **#1529**: `store.owned()` returns false for active subscriptions after app restart — `loadReceipts` used a fixed 300ms delay hoping pending native transactions had been processed, which was unreliable.
- **#1363**: Related ownership-lost-on-reinstall symptoms from the same root causes.

## Changes

**`appstore-adapter.ts`**
- `upsertTransaction`: Create a fallback `SKApplicationReceipt` when the app receipt fails to load, instead of returning without resolving the Promise. This prevents the purchase flow from hanging and ensures `finishTransaction` is eventually called on the native side.
- `loadReceipts`: Replace the fixed 300ms `setTimeout` with `await bridge.pendingTransactionsReady` — a Promise that resolves when the native pending transaction queue has been fully processed. This ensures all transactions from previous sessions are available before the receipt is returned.
- `initializeAppReceipt`: Reset `_appStoreReceiptLoading` flag on the success path (was only reset on error paths).

**`appstore-bridge.ts` / `appstore-bridge-sk2.ts`**
- Add `pendingTransactionsReady` Promise that resolves after `processPendingTransactions` completes and `finalizeTransactionUpdates` has run.

**`appstore-bridge-interface.ts`**
- Add optional `pendingTransactionsReady` to `BridgeInterface`.

## Test plan

- [ ] Purchase a subscription in iOS sandbox — `approved` callback should fire, dialog should not loop
- [ ] Kill and restart the app — `store.owned()` should return true after receipt validation
- [ ] Verify Android is unaffected
- [ ] Run `npm test` — all 12 tests pass

Fixes #1568, #1529. Related: #1363.