### PR TITLE
fix(capacitor): export package.json for Capacitor CLI plugin discovery

### DIFF
--- a/.github/workflows/build-capacitor-ios.yml
+++ b/.github/workflows/build-capacitor-ios.yml
@@ -70,6 +70,7 @@ jobs:
           # time, and peer-dep resolution is stricter than for directory installs).
           TARBALL=$(cd "$GITHUB_WORKSPACE/capacitor" && npm pack --silent)
           npm install "$GITHUB_WORKSPACE/capacitor/$TARBALL"
+          node -e "console.log(require.resolve('capacitor-plugin-cdv-purchase/package.json'))"
           npx cap sync ios
 
       - name: Build iOS

--- a/capacitor/package.json
+++ b/capacitor/package.json
@@ -10,7 +10,8 @@
       "types": "./types/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "capacitor": {
     "ios": { "src": "ios" },


### PR DESCRIPTION
## Summary

Capacitor CLI plugin discovery can resolve capacitor-plugin-cdv-purchase/package.json when scanning installed packages. In pnpm workspace / hoisted monorepo layouts, that failed because the package exports map exposed only ".", so the ./package.json subpath was blocked by Node's package exports rules.

This patch adds ./package.json to the Capacitor package exports map and leaves the existing entrypoint behavior unchanged.

Resolves https://github.com/j3k0/cordova-plugin-purchase/issues/1695

## Changes

- add ./package.json to capacitor/package.json#exports
- add a CI assertion in the existing packed-tarball iOS workflow to verify require.resolve('capacitor-plugin-cdv-purchase/package.json') succeeds before cap sync ios

## Why This Fix

Capacitor CLI discovery relies on reading plugin package metadata. With the current export map, a packed install of capacitor-plugin-cdv-purchase throws ERR_PACKAGE_PATH_NOT_EXPORTED for capacitor-plugin-
cdv-purchase/package.json, which can cause the plugin to be skipped in hoisted or pnpm workspace setups.

Exporting ./package.json is the smallest backward-compatible packaging fix to make the package discoverable without changing runtime behavior, native bridges, or the public JS API.

## Verification

Manual verification performed against a locally packed tarball install:

- before the change, require.resolve('capacitor-plugin-cdv-purchase/package.json') failed with ERR_PACKAGE_PATH_NOT_EXPORTED
- after the change, the same resolution succeeded from an installed tarball package

CI coverage added:

- the existing Capacitor iOS packed-tarball workflow now asserts that require.resolve('capacitor-plugin-cdv-purchase/package.json') succeeds before running npx cap sync ios

## Scope

This is a packaging/discovery compatibility fix only.

No changes were made to:

- runtime purchase logic
- iOS store implementation
- Android billing code
- public JS API