### PR TITLE
fix(ios): honor StoreKit 2 isEligibleForIntroOffer (#1694)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Release Notes - Cordova Plugin Purchase
 
+## Unreleased
+
+#### (ios) Honor StoreKit 2 `isEligibleForIntroOffer` for intro price eligibility
+
+Under StoreKit 2, the app store receipt is always empty — so the adapter's eligibility
+path was short-circuiting and reporting every user as eligible for the introductory
+price, even after they had already redeemed the free trial ([#1694](https://github.com/j3k0/cordova-plugin-purchase/issues/1694)). The native iOS plugin
+(Capacitor and the StoreKit 2 Plugin) now surfaces `Product.SubscriptionInfo.isEligibleForIntroOffer`
+on each loaded product, and the adapter seeds that authoritative answer into the
+eligibility response. When the native answer is available, the receipt-based
+`appStoreDiscountEligibilityDeterminer` is skipped entirely; when only some answers
+are available (e.g. promotional offers), the native answer overlays the determiner's
+response (native wins).
+
+Requires the **StoreKit 2 Plugin** v1.0.5+ on Cordova, or the updated Capacitor plugin
+bundled in this release. Older native builds that don't surface `introPriceEligible`
+continue to work unchanged — eligibility falls back to the existing determiner path.
+
 ## 13.15
 
 ### 13.15.3

--- a/api/interfaces/CdvPurchase.AppleAppStore.Bridge.ValidProduct.md
+++ b/api/interfaces/CdvPurchase.AppleAppStore.Bridge.ValidProduct.md
@@ -17,6 +17,7 @@ Product as loaded from AppStore
 - [group](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md#group)
 - [id](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md#id)
 - [introPrice](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md#introprice)
+- [introPriceEligible](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md#intropriceeligible)
 - [introPriceMicros](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md#intropricemicros)
 - [introPricePaymentMode](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md#intropricepaymentmode)
 - [introPricePeriod](CdvPurchase.AppleAppStore.Bridge.ValidProduct.md#intropriceperiod)
@@ -96,6 +97,19 @@ ___
 • `Optional` **introPrice**: `string`
 
 Localized price for introductory period
+
+___
+
+### introPriceEligible
+
+• `Optional` **introPriceEligible**: `boolean`
+
+Whether the user is eligible for the introductory price.
+
+Populated from StoreKit 2's `Product.SubscriptionInfo.isEligibleForIntroOffer`
+when running on SK2 (iOS 15+). Absent on SK1 and on older native builds that
+don't surface it — in which case the discount eligibility determiner is used
+as before.
 
 ___
 

--- a/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
+++ b/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
@@ -150,7 +150,7 @@ public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
 
                 for product in storeProducts {
                     sk2.products[product.id] = product
-                    validProducts.append(productToDict(product))
+                    validProducts.append(await productToDict(product))
                     validIds.insert(product.id)
                 }
 
@@ -445,7 +445,7 @@ public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @available(iOS 15.0, *)
-    private func productToDict(_ product: Product) -> [String: Any] {
+    private func productToDict(_ product: Product) async -> [String: Any] {
         var dict: [String: Any] = [
             "id": product.id,
             "title": product.displayName,
@@ -478,6 +478,10 @@ public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
                 dict["introPricePeriod"] = intro.period.value
                 dict["introPricePeriodUnit"] = periodUnitToString(intro.period.unit)
                 dict["introPricePaymentMode"] = paymentModeToString(intro.paymentMode)
+                // StoreKit 2 eligibility — honors the user's prior subscription/trial history.
+                // Only meaningful when an intro offer exists; omitted otherwise so older TS
+                // builds that don't know about this field keep their SK1-era behavior.
+                dict["introPriceEligible"] = await subscription.isEligibleForIntroOffer
             }
 
             // Promotional offers (discounts)

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -543,47 +543,50 @@ namespace CdvPurchase {
 
             private async loadEligibility(validProducts: Bridge.ValidProduct[]): Promise<Internal.DiscountEligibilities> {
                 this.log.debug('load eligibility: ' + JSON.stringify(validProducts));
-                if (!this.discountEligibilityDeterminer) {
-                    this.log.debug('No discount eligibility determiner, skipping...');
+
+                // Collect eligibility requests alongside native-provided answers (from
+                // StoreKit 2's isEligibleForIntroOffer, when available).
+                const { requests, nativeAnswers } = Internal.collectEligibilityRequests(validProducts);
+
+                if (requests.length === 0) {
                     return new Internal.DiscountEligibilities([], []);
                 }
 
-                const eligibilityRequests: DiscountEligibilityRequest[] = [];
-                validProducts.forEach(valid => {
-                    valid.discounts?.forEach(discount => {
-                        eligibilityRequests.push({
-                            productId: valid.id,
-                            discountId: discount.id,
-                            discountType: discount.type,
-                        });
-                    });
-                    if ((valid.discounts?.length ?? 0) === 0 && valid.introPrice) {
-                        // sometime apple returns the discounts in the deprecated "introductory" info
-                        // we create a special "discount" with the id "intro" to check for eligibility.
-                        eligibilityRequests.push({
-                            productId: valid.id,
-                            discountId: 'intro',
-                            discountType: 'Introductory',
-                        });
-                    }
-                });
+                // Fast path — if every eligibility answer came from native, we can skip
+                // the receipt fetch and the determiner entirely. This is the common case
+                // for StoreKit 2 where the app store receipt is always empty.
+                const allNative = nativeAnswers.every(a => a !== undefined);
+                if (allNative) {
+                    this.log.debug('native eligibility answers cover all requests, skipping determiner.');
+                    return new Internal.DiscountEligibilities(requests, nativeAnswers as boolean[]);
+                }
 
-                if (eligibilityRequests.length > 0) {
-                    const applicationReceipt = await this.loadAppStoreReceipt();
-                    if (!applicationReceipt || !applicationReceipt.appStoreReceipt) {
-                        this.log.debug('no receipt, assuming introductory price are available.');
-                        return new Internal.DiscountEligibilities(eligibilityRequests, eligibilityRequests.map(r => r.discountType === "Introductory"));
-                    }
-                    else {
-                        this.log.debug('calling discount eligibility determiner.');
-                        const response = await this.callDiscountEligibilityDeterminer(applicationReceipt, eligibilityRequests);
-                        this.log.debug('response: ' + JSON.stringify(response));
-                        return new Internal.DiscountEligibilities(eligibilityRequests, response);
-                    }
+                // Otherwise fall back to the receipt + determiner path, then overlay any
+                // native answers we do have (native wins on conflict — it's authoritative).
+                if (!this.discountEligibilityDeterminer) {
+                    this.log.debug('No discount eligibility determiner; using native answers only where available.');
+                    const defaultForMissing = requests.map(r => r.discountType === 'Introductory');
+                    return new Internal.DiscountEligibilities(
+                        requests,
+                        Internal.mergeNativeEligibility(defaultForMissing, nativeAnswers),
+                    );
+                }
+
+                const applicationReceipt = await this.loadAppStoreReceipt();
+                let response: boolean[];
+                if (!applicationReceipt || !applicationReceipt.appStoreReceipt) {
+                    this.log.debug('no receipt, assuming introductory price are available.');
+                    response = requests.map(r => r.discountType === 'Introductory');
                 }
                 else {
-                    return new Internal.DiscountEligibilities([], []);
+                    this.log.debug('calling discount eligibility determiner.');
+                    response = await this.callDiscountEligibilityDeterminer(applicationReceipt, requests);
+                    this.log.debug('response: ' + JSON.stringify(response));
                 }
+                return new Internal.DiscountEligibilities(
+                    requests,
+                    Internal.mergeNativeEligibility(response, nativeAnswers),
+                );
             }
 
             private callDiscountEligibilityDeterminer(applicationReceipt: ApplicationReceipt, eligibilityRequests: DiscountEligibilityRequest[]): Promise<boolean[]> {

--- a/src/ts/platforms/apple-appstore/appstore-bridge.ts
+++ b/src/ts/platforms/apple-appstore/appstore-bridge.ts
@@ -84,6 +84,16 @@ namespace CdvPurchase {
                 /** Payment mode for introductory price */
                 introPricePaymentMode?: PaymentMode;
 
+                /**
+                 * Whether the user is eligible for the introductory price.
+                 *
+                 * Populated from StoreKit 2's `Product.SubscriptionInfo.isEligibleForIntroOffer`
+                 * when running on SK2 (iOS 15+). Absent on SK1 and on older native builds that
+                 * don't surface it — in which case the discount eligibility determiner is used
+                 * as before.
+                 */
+                introPriceEligible?: boolean;
+
                 /** Available discount offers */
                 discounts?: Discount[];
 

--- a/src/ts/platforms/apple-appstore/appstore-discount.ts
+++ b/src/ts/platforms/apple-appstore/appstore-discount.ts
@@ -38,6 +38,60 @@ namespace CdvPurchase {
           return true;
         }
       }
+
+      /**
+       * Build the pair of (requests, native-provided answers) for every valid product.
+       *
+       * The two arrays are parallel: for each request, the matching `nativeAnswers` entry
+       * is either the native eligibility (from StoreKit 2's `isEligibleForIntroOffer`)
+       * or `undefined` if native did not provide one (SK1 / older native plugin).
+       *
+       * Only Introductory requests can carry a native answer — SK2 does not answer
+       * promotional offer eligibility at the adapter level.
+       */
+      export function collectEligibilityRequests(validProducts: Bridge.ValidProduct[]): {
+        requests: DiscountEligibilityRequest[];
+        nativeAnswers: (boolean | undefined)[];
+      } {
+        const requests: DiscountEligibilityRequest[] = [];
+        const nativeAnswers: (boolean | undefined)[] = [];
+        validProducts.forEach(valid => {
+          valid.discounts?.forEach(discount => {
+            requests.push({
+              productId: valid.id,
+              discountId: discount.id,
+              discountType: discount.type,
+            });
+            nativeAnswers.push(
+              discount.type === 'Introductory' ? valid.introPriceEligible : undefined
+            );
+          });
+          if ((valid.discounts?.length ?? 0) === 0 && valid.introPrice) {
+            requests.push({
+              productId: valid.id,
+              discountId: 'intro',
+              discountType: 'Introductory',
+            });
+            nativeAnswers.push(valid.introPriceEligible);
+          }
+        });
+        return { requests, nativeAnswers };
+      }
+
+      /**
+       * Overlay native-provided eligibility answers on top of a determiner response.
+       *
+       * Native wins on conflict — it's the authoritative source for StoreKit 2.
+       * Determiner response is used where native did not provide an answer (SK1
+       * or older native builds).
+       */
+      export function mergeNativeEligibility(
+        determinerResponse: boolean[],
+        nativeAnswers: (boolean | undefined)[],
+      ): boolean[] {
+        return determinerResponse.map((r, i) =>
+          nativeAnswers[i] !== undefined ? (nativeAnswers[i] as boolean) : r);
+      }
     }
 
   }

--- a/tests/appstore-eligibility.test.ts
+++ b/tests/appstore-eligibility.test.ts
@@ -1,0 +1,154 @@
+import '../www/store';
+
+type ValidProduct = CdvPurchase.AppleAppStore.Bridge.ValidProduct;
+
+const {
+    collectEligibilityRequests,
+    mergeNativeEligibility,
+    DiscountEligibilities,
+} = CdvPurchase.AppleAppStore.Internal;
+
+/**
+ * These tests exercise the pure helpers used by the Apple AppStore adapter's
+ * `loadEligibility`. They cover the fix for #1694 — under StoreKit 2 the app
+ * store receipt is always empty, so the adapter previously returned a blanket
+ * "eligible" answer for every Introductory request. The native plugin now
+ * surfaces `isEligibleForIntroOffer` on each product, and the adapter seeds
+ * those into the eligibility response.
+ */
+describe('AppleAppStore eligibility (#1694)', () => {
+
+    function product(over: Partial<ValidProduct> = {}): ValidProduct {
+        return {
+            id: 'sub.monthly',
+            title: 'Monthly subscription',
+            description: 'A monthly subscription',
+            price: '$4.99',
+            priceMicros: 4990000,
+            currency: 'USD',
+            countryCode: 'US',
+            billingPeriod: 1,
+            billingPeriodUnit: 'Month' as CdvPurchase.IPeriodUnit,
+            introPrice: '$0.00',
+            introPriceMicros: 0,
+            introPricePeriod: 1,
+            introPricePeriodUnit: 'Week' as CdvPurchase.IPeriodUnit,
+            introPricePaymentMode: 'FreeTrial' as CdvPurchase.PaymentMode,
+            ...over,
+        };
+    }
+
+    describe('collectEligibilityRequests', () => {
+
+        test('adds the synthetic "intro" request when discounts is empty and introPrice is set', () => {
+            const { requests, nativeAnswers } = collectEligibilityRequests([product()]);
+            expect(requests).toEqual([{
+                productId: 'sub.monthly',
+                discountId: 'intro',
+                discountType: 'Introductory',
+            }]);
+            expect(nativeAnswers).toEqual([undefined]);
+        });
+
+        test('passes native introPriceEligible=false through as the native answer', () => {
+            const { nativeAnswers } = collectEligibilityRequests([product({ introPriceEligible: false })]);
+            expect(nativeAnswers).toEqual([false]);
+        });
+
+        test('passes native introPriceEligible=true through as the native answer', () => {
+            const { nativeAnswers } = collectEligibilityRequests([product({ introPriceEligible: true })]);
+            expect(nativeAnswers).toEqual([true]);
+        });
+
+        test('only surfaces native answers for Introductory entries, never Subscription', () => {
+            const p = product({
+                introPriceEligible: false,
+                discounts: [
+                    { id: 'promo1', type: 'Subscription',
+                      price: '$2.99', priceMicros: 2990000,
+                      period: 1, periodUnit: 'Month' as CdvPurchase.IPeriodUnit,
+                      paymentMode: 'PayAsYouGo' as CdvPurchase.PaymentMode },
+                ],
+            });
+            const { requests, nativeAnswers } = collectEligibilityRequests([p]);
+            expect(requests.length).toBe(1);
+            expect(requests[0].discountType).toBe('Subscription');
+            // Subscription offers must NOT inherit the intro-offer answer.
+            expect(nativeAnswers).toEqual([undefined]);
+        });
+
+        test('produces no requests for a product without introPrice and without discounts', () => {
+            const p = product({ introPrice: undefined, introPriceMicros: undefined });
+            const { requests, nativeAnswers } = collectEligibilityRequests([p]);
+            expect(requests).toEqual([]);
+            expect(nativeAnswers).toEqual([]);
+        });
+    });
+
+    describe('mergeNativeEligibility', () => {
+
+        test('native answer overrides determiner response', () => {
+            const merged = mergeNativeEligibility([true, true], [false, undefined]);
+            expect(merged).toEqual([false, true]);
+        });
+
+        test('all native = full override', () => {
+            const merged = mergeNativeEligibility([true, true], [false, false]);
+            expect(merged).toEqual([false, false]);
+        });
+
+        test('no native = determiner response passes through unchanged', () => {
+            const merged = mergeNativeEligibility([true, false], [undefined, undefined]);
+            expect(merged).toEqual([true, false]);
+        });
+    });
+
+    describe('DiscountEligibilities — end-to-end shape', () => {
+
+        test('SK2 + introPriceEligible=false → isEligible returns false', () => {
+            const { requests, nativeAnswers } = collectEligibilityRequests([
+                product({ introPriceEligible: false }),
+            ]);
+            // All answers are native → fast path: hand nativeAnswers straight to the class.
+            const elig = new DiscountEligibilities(requests, nativeAnswers as boolean[]);
+            expect(elig.isEligible('sub.monthly', 'Introductory', 'intro')).toBe(false);
+        });
+
+        test('SK2 + introPriceEligible=true → isEligible returns true', () => {
+            const { requests, nativeAnswers } = collectEligibilityRequests([
+                product({ introPriceEligible: true }),
+            ]);
+            const elig = new DiscountEligibilities(requests, nativeAnswers as boolean[]);
+            expect(elig.isEligible('sub.monthly', 'Introductory', 'intro')).toBe(true);
+        });
+
+        test('Old native (no introPriceEligible field) → falls back to determiner=true', () => {
+            const { requests, nativeAnswers } = collectEligibilityRequests([product()]);
+            // Determiner would default to true for Introductory in the "no receipt" branch.
+            const determinerDefault = requests.map(r => r.discountType === 'Introductory');
+            const merged = mergeNativeEligibility(determinerDefault, nativeAnswers);
+            const elig = new DiscountEligibilities(requests, merged);
+            expect(elig.isEligible('sub.monthly', 'Introductory', 'intro')).toBe(true);
+        });
+
+        test('SK1 regression: determiner says [false] and no native answer → false', () => {
+            const { requests, nativeAnswers } = collectEligibilityRequests([product()]);
+            const determinerResponse = [false];
+            const merged = mergeNativeEligibility(determinerResponse, nativeAnswers);
+            const elig = new DiscountEligibilities(requests, merged);
+            expect(elig.isEligible('sub.monthly', 'Introductory', 'intro')).toBe(false);
+        });
+
+        test('Native wins when native and determiner disagree (SK2 authoritative)', () => {
+            // Determiner returns true (wrongly) because receipt is empty under SK2.
+            // Native correctly says the user already redeemed the intro → ineligible.
+            const { requests, nativeAnswers } = collectEligibilityRequests([
+                product({ introPriceEligible: false }),
+            ]);
+            const determinerResponse = [true]; // incorrect SK2 receipt-based default
+            const merged = mergeNativeEligibility(determinerResponse, nativeAnswers);
+            const elig = new DiscountEligibilities(requests, merged);
+            expect(elig.isEligible('sub.monthly', 'Introductory', 'intro')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Fixes [#1694](https://github.com/j3k0/cordova-plugin-purchase/issues/1694) — `appStoreDiscountEligibilityDeterminer` always receives `[true, true]` for `Introductory` eligibility under StoreKit 2, even when the user is already subscribed and no longer eligible for the free trial.

## Root cause

1. `appstore-adapter.ts` sets `needAppReceipt = false` when `useSK2` is active.
2. `loadEligibility` short-circuits when the receipt is empty (always true under SK2) and returns `true` for every `Introductory` request without calling the determiner.
3. Neither the SK2 extension nor the Capacitor native plugin was surfacing StoreKit 2's `Product.SubscriptionInfo.isEligibleForIntroOffer`, so the adapter had no authoritative eligibility signal under SK2.

## Fix

**Native (Capacitor plugin, this repo):** `productToDict` is now `async` and reads `subscription.isEligibleForIntroOffer` when an intro offer exists, setting `introPriceEligible` on the product dict.

**TypeScript bridge:** `introPriceEligible?: boolean` added to `Bridge.ValidProduct` (optional — back-compat with SK1 and older native builds).

**Adapter:** `loadEligibility` now:
- collects eligibility requests alongside native-provided answers (parallel arrays),
- if every request has a native answer, skips `loadAppStoreReceipt` and the determiner entirely (fast path, the common SK2 case),
- otherwise falls back to the determiner path but **overlays** native answers on top of the determiner response (native wins on conflict — it's authoritative for SK2),
- still works on SK1 and on older native builds that don't carry `introPriceEligible`.

The merge logic is factored into two pure helpers (`collectEligibilityRequests`, `mergeNativeEligibility`) under `CdvPurchase.AppleAppStore.Internal` for unit testability.

## Companion PR

- StoreKit 2 Plugin (for Cordova apps): [cordova-plugin-purchase-storekit2 #3](https://github.com/j3k0/cordova-plugin-purchase-storekit2/pull/3) — native surfacing of `isEligibleForIntroOffer`. Requires v1.0.5+.

Capacitor users get the native change directly via the Capacitor plugin in this PR; no extra install.

## Test plan

- [x] New unit tests in `tests/appstore-eligibility.test.ts` (13 cases) cover: native answer present (true/false), native answer absent (fallback to determiner), Introductory vs Subscription offer types, determiner disagreement (native wins), SK1 regression.
- [x] `make all` passes locally — 43/43 tests passing.
- [x] `swiftc -parse` passes on both Swift files.
- [ ] Manual: validate on a sandbox account that has already redeemed the intro offer; confirm `appStoreDiscountEligibilityDeterminer` receives `false` for that product.
- [ ] CI: Unit Tests, iOS Build, Android Build, Capacitor iOS Build, Capacitor Android Build.