### PR TITLE
fix: eliminate race condition in store.update() throttle

### DIFF
--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -371,11 +371,13 @@ namespace CdvPurchase {
                 return;
             }
             const now = +new Date();
-            if (this.lastUpdate > now - this.minTimeBetweenUpdates) {
+            const prevLastUpdate = this.lastUpdate;
+            this.lastUpdate = now;
+            if (prevLastUpdate > now - this.minTimeBetweenUpdates) {
+                this.lastUpdate = prevLastUpdate;
                 this.log.info('Skipping store.update() as the last call occurred less than store.minTimeBetweenUpdates millis ago.');
                 return;
             }
-            this.lastUpdate = now;
             // Load products metadata
             for (const registration of this.registeredProducts.byPlatform()) {
                 const adapter = this.adapters.findReady(registration.platform);

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -168,6 +168,118 @@ describe('CDVPurchase', () => {
     });
   });
 
+  describe('store.update() throttle', () => {
+    beforeEach(() => {
+      if (CdvPurchase.store.getAdapter(CdvPurchase.Platform.TEST)) {
+        // @ts-ignore - accessing private property for testing
+        CdvPurchase.store.adapters = new CdvPurchase.Internal.Adapters();
+        // @ts-ignore - reset the initialized flag
+        CdvPurchase.store.initializedHasBeenCalled = false;
+      }
+      // @ts-ignore - reset the storefront cache
+      CdvPurchase.store._storefronts = new CdvPurchase.Internal.Storefronts(CdvPurchase.store.log.child('Storefronts'));
+    });
+
+    test('should block concurrent update() calls within throttle window', async () => {
+      CdvPurchase.store.register({
+        id: 'throttle-test-product',
+        type: CdvPurchase.ProductType.CONSUMABLE,
+        platform: CdvPurchase.Platform.TEST,
+      });
+
+      await CdvPurchase.store.initialize([CdvPurchase.Platform.TEST]);
+      await new Promise<void>(resolve => CdvPurchase.store.ready(() => resolve()));
+
+      // @ts-ignore - accessing private property for testing
+      CdvPurchase.store.minTimeBetweenUpdates = 600000;
+
+      const infoLogs: string[] = [];
+      const originalInfo = CdvPurchase.store.log.info.bind(CdvPurchase.store.log);
+      // @ts-ignore - monkey-patching log for testing
+      CdvPurchase.store.log.info = (msg: string) => {
+        infoLogs.push(msg);
+        originalInfo(msg);
+      };
+
+      const [result1, result2] = await Promise.all([
+        CdvPurchase.store.update(),
+        CdvPurchase.store.update(),
+      ]);
+
+      // @ts-ignore
+      CdvPurchase.store.log.info = originalInfo;
+
+      const updateSkipped = infoLogs.filter(msg => msg.includes('Skipping store.update()')).length;
+      expect(updateSkipped).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should allow update() after throttle window expires', async () => {
+      CdvPurchase.store.register({
+        id: 'throttle-window-product',
+        type: CdvPurchase.ProductType.CONSUMABLE,
+        platform: CdvPurchase.Platform.TEST,
+      });
+
+      await CdvPurchase.store.initialize([CdvPurchase.Platform.TEST]);
+      await new Promise<void>(resolve => CdvPurchase.store.ready(() => resolve()));
+
+      // @ts-ignore - accessing private property for testing
+      CdvPurchase.store.minTimeBetweenUpdates = 50;
+
+      await CdvPurchase.store.update();
+
+      await new Promise(resolve => setTimeout(resolve, 60));
+
+      const infoLogs: string[] = [];
+      const originalInfo = CdvPurchase.store.log.info.bind(CdvPurchase.store.log);
+      // @ts-ignore - monkey-patching log for testing
+      CdvPurchase.store.log.info = (msg: string) => {
+        infoLogs.push(msg);
+        originalInfo(msg);
+      };
+
+      await CdvPurchase.store.update();
+
+      // @ts-ignore
+      CdvPurchase.store.log.info = originalInfo;
+
+      const updateSkipped = infoLogs.filter(msg => msg.includes('Skipping store.update()')).length;
+      expect(updateSkipped).toBe(0);
+    });
+
+    test('should block sequential update() calls within throttle window', async () => {
+      CdvPurchase.store.register({
+        id: 'throttle-sequential-product',
+        type: CdvPurchase.ProductType.CONSUMABLE,
+        platform: CdvPurchase.Platform.TEST,
+      });
+
+      await CdvPurchase.store.initialize([CdvPurchase.Platform.TEST]);
+      await new Promise<void>(resolve => CdvPurchase.store.ready(() => resolve()));
+
+      // @ts-ignore - accessing private property for testing
+      CdvPurchase.store.minTimeBetweenUpdates = 600000;
+
+      await CdvPurchase.store.update();
+
+      const infoLogs: string[] = [];
+      const originalInfo = CdvPurchase.store.log.info.bind(CdvPurchase.store.log);
+      // @ts-ignore - monkey-patching log for testing
+      CdvPurchase.store.log.info = (msg: string) => {
+        infoLogs.push(msg);
+        originalInfo(msg);
+      };
+
+      await CdvPurchase.store.update();
+
+      // @ts-ignore
+      CdvPurchase.store.log.info = originalInfo;
+
+      const updateSkipped = infoLogs.filter(msg => msg.includes('Skipping store.update()')).length;
+      expect(updateSkipped).toBe(1);
+    });
+  });
+
   describe('Integration Tests', () => {
     // Reset the store before each test
     beforeEach(() => {


### PR DESCRIPTION
## Summary

- Fix race condition in `store.update()` where two near-simultaneous calls could both pass the throttle check before either sets `lastUpdate`, since `lastUpdate` was only set **after** the check
- Set `lastUpdate` immediately before the throttle check; if the call is throttled, restore the previous value so the throttle window is not extended
- Add 3 tests: concurrent calls within throttle window, sequential calls within window, and calls after window expires

## Test plan

- [x] New test: concurrent `Promise.all([store.update(), store.update()])` — at least one is skipped
- [x] New test: sequential call within window is throttled
- [x] New test: call after window expires is allowed
- [x] Full test suite passes (64 tests)
- [x] `make all` passes