### PR TITLE
feat: add store.obfuscator for configurable applicationUsername obfuscation

### DIFF
--- a/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
+++ b/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
@@ -186,9 +186,9 @@ public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
         Task {
             do {
                 var options: Set<Product.PurchaseOption> = []
-                if let username = call.getString("applicationUsername") {
+                if let username = call.getString("applicationUsername"), let uuid = UUID(uuidString: username) {
                     options.insert(.appAccountToken(
-                        UUID(uuidString: username) ?? UUID()))
+                        uuid))
                 }
                 if quantity > 1 {
                     options.insert(.quantity(quantity))

--- a/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
+++ b/capacitor/ios/Sources/PurchasePlugin/PurchasePlugin.swift
@@ -186,9 +186,12 @@ public class PurchasePlugin: CAPPlugin, CAPBridgedPlugin {
         Task {
             do {
                 var options: Set<Product.PurchaseOption> = []
-                if let username = call.getString("applicationUsername"), let uuid = UUID(uuidString: username) {
-                    options.insert(.appAccountToken(
-                        uuid))
+                if let username = call.getString("applicationUsername"), !username.isEmpty {
+                    if let uuid = UUID(uuidString: username) {
+                        options.insert(.appAccountToken(uuid))
+                    } else {
+                        debugLog("applicationUsername is not a valid UUID, appAccountToken will not be set: \(username)")
+                    }
                 }
                 if quantity > 1 {
                     options.insert(.quantity(quantity))

--- a/src/ts/internal/adapters.ts
+++ b/src/ts/internal/adapters.ts
@@ -66,6 +66,12 @@ namespace CdvPurchase
             /** Retrieves the application username */
             getApplicationUsername: () => string | undefined;
 
+            /** Obfuscate the application username for the given platform */
+            obfuscateUsername: (applicationUsername: string, platform: CdvPurchase.Platform) => string | undefined;
+
+            /** The obfuscation strategy */
+            obfuscator?: CdvPurchase.Obfuscator;
+
             /** Functions used to decorate the API */
             apiDecorators: ProductDecorator & TransactionDecorator & OfferDecorator & ReceiptDecorator;
 

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -99,6 +99,21 @@ namespace CdvPurchase {
             _products: SKProduct[] = [];
             get products(): Product[] { return this._products; }
 
+            /**
+             * Resolve the username string passed to the native bridge for a
+             * purchase. SK1 + 'legacy' keeps the raw username for backward
+             * compatibility; every other mode obfuscates through the
+             * configured strategy. 'disabled' always returns the raw value.
+             */
+            private resolveBridgeUsername(): string | undefined {
+                const raw = this.context.getApplicationUsername();
+                if (!raw) return undefined;
+                const obfuscator = this.context.obfuscator ?? 'legacy';
+                if (obfuscator === 'disabled') return raw;
+                if (obfuscator === 'legacy' && !this.useSK2) return raw;
+                return this.context.obfuscateUsername(raw, Platform.APPLE_APPSTORE);
+            }
+
             /** Find a given product from ID */
             getProduct(id: string): SKProduct | undefined { return this._products.find(p => p.id === id); }
 
@@ -692,12 +707,8 @@ namespace CdvPurchase {
                     // When we switch AppStore user, the cached receipt isn't from the new user.
                     // so after a purchase, we want to make sure we're using the receipt from the logged in user.
                     this.forceReceiptReload = true;
-                    const rawUsername = additionalData?.applicationUsername || this.context.getApplicationUsername();
-                    const obfuscator = this.context.obfuscator ?? 'legacy';
-                    const skipObfuscation = !this.useSK2 && (obfuscator === 'legacy' || obfuscator === 'disabled');
-                    const username = (rawUsername && skipObfuscation)
-                        ? rawUsername
-                        : (rawUsername ? this.context.obfuscateUsername(rawUsername, Platform.APPLE_APPSTORE) : undefined);
+                    warnIfDeprecatedAdditionalUsername(this.log, additionalData);
+                    const username = this.resolveBridgeUsername();
                     this.bridge.purchase(offer.productId, quantity, username, discount, success, error);
                 });
             }
@@ -950,6 +961,15 @@ namespace CdvPurchase {
 
         function appStoreError(code: ErrorCode, message: string, productId: string | null) {
             return storeError(code, message, Platform.APPLE_APPSTORE, productId);
+        }
+
+        let deprecatedAdditionalUsernameNoticed = false;
+        function warnIfDeprecatedAdditionalUsername(log: Logger, additionalData: CdvPurchase.AdditionalData | undefined) {
+            // Bracket access avoids the @deprecated read warning on the field.
+            if (!additionalData || !(additionalData as { [k: string]: any })['applicationUsername']) return;
+            if (deprecatedAdditionalUsernameNoticed) return;
+            deprecatedAdditionalUsernameNoticed = true;
+            log.warn('additionalData.applicationUsername is deprecated and ignored. Set store.applicationUsername instead.');
         }
     }
 }

--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -692,7 +692,13 @@ namespace CdvPurchase {
                     // When we switch AppStore user, the cached receipt isn't from the new user.
                     // so after a purchase, we want to make sure we're using the receipt from the logged in user.
                     this.forceReceiptReload = true;
-                    this.bridge.purchase(offer.productId, quantity, this.context.getApplicationUsername(), discount, success, error);
+                    const rawUsername = additionalData?.applicationUsername || this.context.getApplicationUsername();
+                    const obfuscator = this.context.obfuscator ?? 'legacy';
+                    const skipObfuscation = !this.useSK2 && (obfuscator === 'legacy' || obfuscator === 'disabled');
+                    const username = (rawUsername && skipObfuscation)
+                        ? rawUsername
+                        : (rawUsername ? this.context.obfuscateUsername(rawUsername, Platform.APPLE_APPSTORE) : undefined);
+                    this.bridge.purchase(offer.productId, quantity, username, discount, success, error);
                 });
             }
 

--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -478,12 +478,8 @@ namespace CdvPurchase {
 
             /** @inheritDoc */
             async order(offer: GOffer, additionalData: CdvPurchase.AdditionalData): Promise<IError | undefined> {
-                const username = additionalData?.applicationUsername || this.context.getApplicationUsername();
-                if (username && !additionalData?.googlePlay?.accountId) {
-                    if (!additionalData) additionalData = {};
-                    if (!additionalData.googlePlay) additionalData.googlePlay = {};
-                    additionalData.googlePlay.accountId = this.context.obfuscateUsername(username, Platform.GOOGLE_PLAY);
-                }
+                warnIfDeprecatedAdditionalUsername(this.log, additionalData);
+                additionalData = withObfuscatedAccountId(additionalData, this.context);
                 return new Promise(resolve => {
                     this.log.info("Order - " + JSON.stringify(offer));
                     const buySuccess = () => resolve(undefined);
@@ -620,6 +616,32 @@ namespace CdvPurchase {
                     });
                 });
             }
+        }
+
+        let deprecatedAdditionalUsernameNoticed = false;
+        function warnIfDeprecatedAdditionalUsername(log: Logger, additionalData: CdvPurchase.AdditionalData | undefined) {
+            // Bracket access avoids the @deprecated read warning on the field.
+            if (!additionalData || !(additionalData as { [k: string]: any })['applicationUsername']) return;
+            if (deprecatedAdditionalUsernameNoticed) return;
+            deprecatedAdditionalUsernameNoticed = true;
+            log.warn('additionalData.applicationUsername is deprecated and ignored. Set store.applicationUsername instead.');
+        }
+
+        /**
+         * Return a copy of `additionalData` with `googlePlay.accountId` populated
+         * from `store.applicationUsername` (via the configured obfuscator) when
+         * not already provided by the caller. Never mutates the input.
+         */
+        function withObfuscatedAccountId(additionalData: CdvPurchase.AdditionalData | undefined, context: Internal.AdapterContext): CdvPurchase.AdditionalData {
+            const next: CdvPurchase.AdditionalData = { ...(additionalData ?? {}) };
+            next.googlePlay = { ...(additionalData?.googlePlay ?? {}) };
+            if (!next.googlePlay.accountId) {
+                const username = context.getApplicationUsername();
+                if (username) {
+                    next.googlePlay.accountId = context.obfuscateUsername(username, Platform.GOOGLE_PLAY);
+                }
+            }
+            return next;
         }
 
         function playStoreError(code: ErrorCode, message: string, productId: string | null) {

--- a/src/ts/platforms/google-play/googleplay-adapter.ts
+++ b/src/ts/platforms/google-play/googleplay-adapter.ts
@@ -478,6 +478,12 @@ namespace CdvPurchase {
 
             /** @inheritDoc */
             async order(offer: GOffer, additionalData: CdvPurchase.AdditionalData): Promise<IError | undefined> {
+                const username = additionalData?.applicationUsername || this.context.getApplicationUsername();
+                if (username && !additionalData?.googlePlay?.accountId) {
+                    if (!additionalData) additionalData = {};
+                    if (!additionalData.googlePlay) additionalData.googlePlay = {};
+                    additionalData.googlePlay.accountId = this.context.obfuscateUsername(username, Platform.GOOGLE_PLAY);
+                }
                 return new Promise(resolve => {
                     this.log.info("Order - " + JSON.stringify(offer));
                     const buySuccess = () => resolve(undefined);

--- a/src/ts/platforms/google-play/googleplay-bridge-capacitor.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge-capacitor.ts
@@ -183,11 +183,7 @@ namespace CdvPurchase {
             }
 
             function extendAdditionalData(ad?: CdvPurchase.AdditionalData): AdditionalData {
-                const additionalData: AdditionalData = ensureObject(ad?.googlePlay);
-                if (!additionalData.accountId && ad?.applicationUsername) {
-                    additionalData.accountId = Utils.md5(ad.applicationUsername);
-                }
-                return additionalData;
+                return ensureObject(ad?.googlePlay);
             }
         }
     }

--- a/src/ts/platforms/google-play/googleplay-bridge.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge.ts
@@ -160,7 +160,7 @@ namespace CdvPurchase {
                 /** String in JSON format that contains details about the purchase order. */
                 receipt: string;
 
-                /** Obfuscated account id specified at purchase - by default md5(applicationUsername) */
+                /** Obfuscated account id specified at purchase, value depends on store.obfuscator setting */
                 accountId: string;
 
                 /** Obfuscated profile id specified at purchase - used when a single user can have multiple profiles */

--- a/src/ts/platforms/google-play/googleplay-bridge.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge.ts
@@ -160,7 +160,7 @@ namespace CdvPurchase {
                 /** String in JSON format that contains details about the purchase order. */
                 receipt: string;
 
-                /** Obfuscated account id specified at purchase, value depends on store.obfuscator setting */
+                /** Obfuscated account id specified at purchase. Format depends on `store.obfuscator`. */
                 accountId: string;
 
                 /** Obfuscated profile id specified at purchase - used when a single user can have multiple profiles */

--- a/src/ts/platforms/google-play/googleplay-bridge.ts
+++ b/src/ts/platforms/google-play/googleplay-bridge.ts
@@ -59,7 +59,9 @@ namespace CdvPurchase {
             /**
              * Obfuscated user account identifier
              *
-             * Default to md5(store.applicationUsername)
+             * Populated by the adapter using `store.obfuscateUsername()`.
+             * Format depends on `store.obfuscator` setting.
+             * @see {@link CdvPurchase.Store.obfuscator}
              */
             accountId?: string;
 
@@ -366,11 +368,7 @@ namespace CdvPurchase {
             }
 
             function extendAdditionalData(ad?: CdvPurchase.AdditionalData): AdditionalData {
-                const additionalData: AdditionalData = ensureObject(ad?.googlePlay);
-                if (!additionalData.accountId && ad?.applicationUsername) {
-                    additionalData.accountId = Utils.md5(ad.applicationUsername);
-                }
-                return additionalData;
+                return ensureObject(ad?.googlePlay);
             }
         }
     }

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -121,27 +121,24 @@ namespace CdvPurchase {
         /**
          * Obfuscation strategy for the application username.
          *
-         * Controls how `applicationUsername` is transformed before being sent to
-         * each platform's native API. See {@link Obfuscator} for available options.
+         * Controls how `applicationUsername` is transformed before being sent
+         * to each platform's native API. `'uuid'` is the recommended setting
+         * for new integrations; the default `'legacy'` exists only for
+         * backward compatibility with server-side modules that already
+         * correlate against the raw 32-hex MD5 value.
          *
          * @default 'legacy'
          * @see {@link Obfuscator}
          */
         public obfuscator?: CdvPurchase.Obfuscator;
 
-        /** @internal Tracks whether the deprecation warning for 'legacy' has been emitted */
-        private _legacyObfuscatorWarningEmitted: boolean = false;
+        /** @internal Tracks whether the info notice for 'legacy' has been emitted */
+        private _legacyObfuscatorNoticeEmitted: boolean = false;
 
         /**
          * Obfuscate the application username according to the configured obfuscation strategy.
          *
-         * The output format depends on the obfuscator and platform:
-         * - `'legacy'` + GOOGLE_PLAY: raw MD5 hash (32 hex chars, no dashes)
-         * - `'legacy'` + APPLE_APPSTORE: MD5 hash formatted as UUIDv3
-         * - `'legacy'` + others: MD5 hash formatted as UUIDv3
-         * - `'uuid'` + any platform: MD5 hash formatted as UUIDv3
-         * - `'disabled'` + any platform: raw value (no transformation)
-         * - Custom function: result of `fn(username, platform)`
+         * See {@link Obfuscator} for the per-mode output format.
          *
          * @internal
          */
@@ -149,12 +146,6 @@ namespace CdvPurchase {
             if (!applicationUsername) return undefined;
 
             const obfuscator = this.obfuscator ?? 'legacy';
-
-            // Emit deprecation warning for 'legacy' mode (once)
-            if (obfuscator === 'legacy' && !this._legacyObfuscatorWarningEmitted) {
-                this._legacyObfuscatorWarningEmitted = true;
-                this.log.warn('store.obfuscator = "legacy" is deprecated. Use "uuid" for new integrations. See https://github.com/j3k0/cordova-plugin-purchase/issues/1665');
-            }
 
             if (typeof obfuscator === 'function') {
                 return obfuscator(applicationUsername, platform);
@@ -167,17 +158,16 @@ namespace CdvPurchase {
                     return Utils.md5toUUID(applicationUsername);
                 case 'legacy':
                 default:
-                    switch (platform) {
-                        case Platform.GOOGLE_PLAY:
-                            // Backward-compatible: raw MD5 hash (32 hex chars, no dashes)
-                            return Utils.md5(applicationUsername);
-                        case Platform.APPLE_APPSTORE:
-                            // UUIDv3 format (works for both SK1 and SK2)
-                            // SK1 accepts any string, SK2 requires valid UUID
-                            return Utils.md5toUUID(applicationUsername);
-                        default:
-                            return Utils.md5toUUID(applicationUsername);
+                    if (!this._legacyObfuscatorNoticeEmitted) {
+                        this._legacyObfuscatorNoticeEmitted = true;
+                        this.log.info('store.obfuscator defaults to "legacy" for backward compatibility. New integrations should set store.obfuscator = "uuid". See https://github.com/j3k0/cordova-plugin-purchase/issues/1665');
                     }
+                    if (platform === Platform.GOOGLE_PLAY) {
+                        // Backward-compatible: raw MD5 hash (32 hex chars, no dashes)
+                        return Utils.md5(applicationUsername);
+                    }
+                    // UUIDv3 format — valid for Apple appAccountToken (SK1 + SK2) and any other platform
+                    return Utils.md5toUUID(applicationUsername);
             }
         }
 

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -12,6 +12,7 @@
 /// <reference path="internal/transaction-monitor.ts" />
 /// <reference path="internal/receipts-monitor.ts" />
 /// <reference path="internal/expiry-monitor.ts" />
+/// <reference path="utils/to-uuid.ts" />
 
 /**
  * Namespace for the cordova-plugin-purchase plugin.
@@ -97,8 +98,15 @@ namespace CdvPurchase {
         /**
          * Return the identifier of the user for your application.
          *
-         * **Note:** Apple AppStore requires an UUIDv4 if you want it to appear as the "appAccountToken" in
-         * the transaction data.
+         * This value is obfuscated according to {@link Store.obfuscator} before being
+         * sent to the native platform API. The default obfuscator (`'legacy'`) hashes
+         * or formats the value so the original username is never transmitted in cleartext.
+         *
+         * For Apple's App Store, the obfuscated value is used as `appAccountToken`
+         * (which must be a valid UUID when using StoreKit 2).
+         *
+         * You can also pass it per-transaction via `additionalData.applicationUsername`
+         * in `store.order()` or `store.requestPayment()`, which takes priority.
          */
         public applicationUsername?: string | (() => string | undefined);
 
@@ -108,6 +116,69 @@ namespace CdvPurchase {
         getApplicationUsername(): string | undefined {
             if (this.applicationUsername instanceof Function) return this.applicationUsername();
             return this.applicationUsername;
+        }
+
+        /**
+         * Obfuscation strategy for the application username.
+         *
+         * Controls how `applicationUsername` is transformed before being sent to
+         * each platform's native API. See {@link Obfuscator} for available options.
+         *
+         * @default 'legacy'
+         * @see {@link Obfuscator}
+         */
+        public obfuscator?: CdvPurchase.Obfuscator;
+
+        /** @internal Tracks whether the deprecation warning for 'legacy' has been emitted */
+        private _legacyObfuscatorWarningEmitted: boolean = false;
+
+        /**
+         * Obfuscate the application username according to the configured obfuscation strategy.
+         *
+         * The output format depends on the obfuscator and platform:
+         * - `'legacy'` + GOOGLE_PLAY: raw MD5 hash (32 hex chars, no dashes)
+         * - `'legacy'` + APPLE_APPSTORE: MD5 hash formatted as UUIDv3
+         * - `'legacy'` + others: MD5 hash formatted as UUIDv3
+         * - `'uuid'` + any platform: MD5 hash formatted as UUIDv3
+         * - `'disabled'` + any platform: raw value (no transformation)
+         * - Custom function: result of `fn(username, platform)`
+         *
+         * @internal
+         */
+        obfuscateUsername(applicationUsername: string, platform: CdvPurchase.Platform): string | undefined {
+            if (!applicationUsername) return undefined;
+
+            const obfuscator = this.obfuscator ?? 'legacy';
+
+            // Emit deprecation warning for 'legacy' mode (once)
+            if (obfuscator === 'legacy' && !this._legacyObfuscatorWarningEmitted) {
+                this._legacyObfuscatorWarningEmitted = true;
+                this.log.warn('store.obfuscator = "legacy" is deprecated. Use "uuid" for new integrations. See https://github.com/j3k0/cordova-plugin-purchase/issues/1665');
+            }
+
+            if (typeof obfuscator === 'function') {
+                return obfuscator(applicationUsername, platform);
+            }
+
+            switch (obfuscator) {
+                case 'disabled':
+                    return applicationUsername;
+                case 'uuid':
+                    return Utils.md5toUUID(applicationUsername);
+                case 'legacy':
+                default:
+                    switch (platform) {
+                        case Platform.GOOGLE_PLAY:
+                            // Backward-compatible: raw MD5 hash (32 hex chars, no dashes)
+                            return Utils.md5(applicationUsername);
+                        case Platform.APPLE_APPSTORE:
+                            // UUIDv3 format (works for both SK1 and SK2)
+                            // SK1 accepts any string, SK2 requires valid UUID
+                            return Utils.md5toUUID(applicationUsername);
+                        default:
+                            return Utils.md5toUUID(applicationUsername);
+                    }
+            }
         }
 
         /**
@@ -228,6 +299,7 @@ namespace CdvPurchase {
             this._validator = new Internal.Validator({
                 adapters: this.adapters,
                 getApplicationUsername: this.getApplicationUsername.bind(this),
+                obfuscateUsername: this.obfuscateUsername.bind(this),
                 get localReceipts() { return store.localReceipts; },
                 get validator() { return store.validator; },
                 get validator_privacy_policy() { return store.validator_privacy_policy; },
@@ -327,6 +399,8 @@ namespace CdvPurchase {
                 error: this.triggerError.bind(this),
                 get verbosity() { return store.verbosity; },
                 getApplicationUsername() { return store.getApplicationUsername() },
+                obfuscateUsername: (username: string, platform: CdvPurchase.Platform) => store.obfuscateUsername(username, platform),
+                get obfuscator() { return store.obfuscator; },
                 get listener() { return store.listener; },
                 get log() { return store.log; },
                 get registeredProducts() { return store.registeredProducts; },

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -250,23 +250,16 @@ namespace CdvPurchase {
     export interface AdditionalData {
 
         /**
-         * The application's user identifier, passed to `store.order()` or `store.requestPayment()`.
+         * The application's user identifier.
          *
-         * The value is obfuscated according to {@link Store.obfuscator} before being sent to
-         * the native platform API. The raw value is also sent to the receipt validator
-         * as `applicationUsername` alongside the `obfuscatedUsername`.
+         * @deprecated Set {@link Store.applicationUsername} instead. The
+         * per-transaction value is ignored — adapters always read the
+         * store-level username so receipt validation later (which doesn't
+         * have access to the original additionalData) sees the same value
+         * that was sent to the native API at purchase time. Passing this
+         * field logs a one-shot notice.
          */
         applicationUsername?: string;
-
-        /**
-         * The obfuscated username, derived from `applicationUsername` by applying
-         * {@link Store.obfuscator}. Sent to the receipt validator alongside the
-         * raw `applicationUsername` so the server can correlate obfuscated IDs
-         * from Apple/Google server notifications with the original user.
-         *
-         * This field is populated automatically — do not set it manually.
-         */
-        obfuscatedUsername?: string;
 
         /**
          * Quantity of items to purchase.
@@ -294,26 +287,27 @@ namespace CdvPurchase {
      * Controls how `applicationUsername` is transformed before being sent to
      * each platform's native API.
      *
-     * - `'legacy'` (default) — Preserves backward compatibility:
+     * - `'uuid'` — **Recommended.** MD5 hash formatted as UUIDv3 on all
+     *   platforms. Deterministic, valid UUID, works as Apple's
+     *   `appAccountToken` (SK1 + SK2) and Google Play's
+     *   `obfuscatedAccountId`.
+     *
+     * - `'legacy'` (default) — Only use this when an existing server-side
+     *   integration already correlates against the original 32-hex MD5 value
+     *   sent on Google Play. New integrations should pick `'uuid'`.
      *   - Google Play: raw MD5 hash (32 hex chars)
-     *   - Apple AppStore: MD5 hash formatted as UUIDv3 (36 chars with dashes)
+     *   - Apple AppStore (SK2): MD5 hash formatted as UUIDv3
+     *   - Apple AppStore (SK1, deprecated): raw username, unchanged
      *   - Other platforms: MD5 hash formatted as UUIDv3
-     *   - Note: for Apple SK1 transactions, the adapter passes the raw username instead
-     *     of the obfuscated value (backward compatibility).
-     *   - **Deprecated**: will be replaced by `'uuid'` in a future major version.
      *
-     * - `'uuid'` — MD5 hash formatted as UUIDv3 on all platforms.
-     *   Recommended for new integrations. **Breaking change** for Google Play:
-     *   `obfuscatedExternalAccountId` format changes from 32 hex chars to
-     *   36-char UUID format.
-     *
-     * - `'disabled'` — No obfuscation. The raw `applicationUsername` value is
+     * - `'disabled'` — No obfuscation. The raw `applicationUsername` is
      *   passed through to all platforms. For Apple SK2, the value must be a
-     *   valid UUIDv4 string or `appAccountToken` will not be set.
+     *   valid UUID string or `appAccountToken` will not be set.
      *
-     * - Custom function — `(username: string, platform: Platform) => string`
+     * - Custom function — `(username: string, platform: Platform) => string`.
      *   Receives the raw username and platform, returns the obfuscated value.
-     *   For Apple SK2, must return a valid UUIDv4 string.
+     *   For Apple (both SK1 and SK2), the function must return a valid UUID
+     *   string.
      *
      * @see {@link Store.obfuscator}
      * @see {@link https://github.com/j3k0/cordova-plugin-purchase/issues/1665}

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -249,8 +249,24 @@ namespace CdvPurchase {
      */
     export interface AdditionalData {
 
-        /** The application's user identifier, will be obfuscated with md5 to fill `accountId` if necessary */
+        /**
+         * The application's user identifier, passed to `store.order()` or `store.requestPayment()`.
+         *
+         * The value is obfuscated according to {@link Store.obfuscator} before being sent to
+         * the native platform API. The raw value is also sent to the receipt validator
+         * as `applicationUsername` alongside the `obfuscatedUsername`.
+         */
         applicationUsername?: string;
+
+        /**
+         * The obfuscated username, derived from `applicationUsername` by applying
+         * {@link Store.obfuscator}. Sent to the receipt validator alongside the
+         * raw `applicationUsername` so the server can correlate obfuscated IDs
+         * from Apple/Google server notifications with the original user.
+         *
+         * This field is populated automatically — do not set it manually.
+         */
+        obfuscatedUsername?: string;
 
         /**
          * Quantity of items to purchase.
@@ -271,6 +287,36 @@ namespace CdvPurchase {
         /** Apple AppStore specific additional data */
         appStore?: AppleAppStore.AdditionalData;
     }
+
+    /**
+     * Obfuscation strategy for the application username.
+     *
+     * Controls how `applicationUsername` is transformed before being sent to
+     * each platform's native API.
+     *
+     * - `'legacy'` (default) — Preserves backward compatibility:
+     *   - Google Play: raw MD5 hash (32 hex chars)
+     *   - Apple SK2: MD5 hash formatted as UUIDv3 (36 chars with dashes)
+     *   - Apple SK1: raw value (no transformation)
+     *   - **Deprecated**: will be replaced by `'uuid'` in a future major version.
+     *
+     * - `'uuid'` — MD5 hash formatted as UUIDv3 on all platforms.
+     *   Recommended for new integrations. **Breaking change** for Google Play:
+     *   `obfuscatedExternalAccountId` format changes from 32 hex chars to
+     *   36-char UUID format.
+     *
+     * - `'disabled'` — No obfuscation. The raw `applicationUsername` value is
+     *   passed through to all platforms. For Apple SK2, the value must be a
+     *   valid UUIDv4 string or `appAccountToken` will not be set.
+     *
+     * - Custom function — `(username: string, platform: Platform) => string`
+     *   Receives the raw username and platform, returns the obfuscated value.
+     *   For Apple SK2, must return a valid UUIDv4 string.
+     *
+     * @see {@link Store.obfuscator}
+     * @see {@link https://github.com/j3k0/cordova-plugin-purchase/issues/1665}
+     */
+    export type Obfuscator = 'legacy' | 'uuid' | 'disabled' | ((applicationUsername: string, platform: Platform) => string);
 
     /**
      * Purchase platforms supported by the plugin

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -296,8 +296,10 @@ namespace CdvPurchase {
      *
      * - `'legacy'` (default) — Preserves backward compatibility:
      *   - Google Play: raw MD5 hash (32 hex chars)
-     *   - Apple SK2: MD5 hash formatted as UUIDv3 (36 chars with dashes)
-     *   - Apple SK1: raw value (no transformation)
+     *   - Apple AppStore: MD5 hash formatted as UUIDv3 (36 chars with dashes)
+     *   - Other platforms: MD5 hash formatted as UUIDv3
+     *   - Note: for Apple SK1 transactions, the adapter passes the raw username instead
+     *     of the obfuscated value (backward compatibility).
      *   - **Deprecated**: will be replaced by `'uuid'` in a future major version.
      *
      * - `'uuid'` — MD5 hash formatted as UUIDv3 on all platforms.

--- a/src/ts/utils/to-uuid.ts
+++ b/src/ts/utils/to-uuid.ts
@@ -1,0 +1,29 @@
+namespace CdvPurchase {
+    export namespace Utils {
+
+        /**
+         * Convert a string to a UUIDv3-like format using MD5 hashing.
+         *
+         * Takes an input string, computes its MD5 hash, then formats the 32 hex
+         * characters as a UUID with version nibble set to '3' (MD5) and variant
+         * nibble set to '8' (RFC 4122).
+         *
+         * This produces a deterministic, valid UUID suitable for Apple's SK2
+         * `appAccountToken` and Google Play's `obfuscatedAccountId`.
+         *
+         * @param str - The input string to hash and format
+         * @returns A UUIDv3-like string (36 chars with dashes), or empty string if input is empty
+         */
+        export function md5toUUID(str: string): string {
+            if (!str) return '';
+            const hash = Utils.md5(str);
+            // UUID format: xxxxxxxx-xxxx-3xxx-8xxx-xxxxxxxxxxxx
+            // Position 12: version '3' (MD5), Position 16: variant '8' (RFC 4122)
+            return hash.substring(0, 8) + '-'
+                + hash.substring(8, 12) + '-'
+                + '3' + hash.substring(13, 16) + '-'
+                + '8' + hash.substring(17, 20) + '-'
+                + hash.substring(20, 32);
+        }
+    }
+}

--- a/src/ts/validator/validator-request.ts
+++ b/src/ts/validator/validator-request.ts
@@ -49,6 +49,15 @@ namespace CdvPurchase {
                      *
                      * @optional */
                     applicationUsername?: string | number;
+
+                    /**
+                     * The obfuscated form of `applicationUsername`, derived by applying
+                     * `store.obfuscator`. The server can use this to correlate obfuscated
+                     * IDs from Apple/Google server notifications (e.g. `appAccountToken`,
+                     * `obfuscatedExternalAccountId`) with the original user.
+                     *
+                     * @optional */
+                    obfuscatedUsername?: string;
                 };
 
                 /** Microsoft license information */

--- a/src/ts/validator/validator.ts
+++ b/src/ts/validator/validator.ts
@@ -213,7 +213,7 @@ namespace CdvPurchase {
                 const body = await adapter?.receiptValidationBody(receipt);
                 if (!body) return;
 
-                // Add the applicationUsername
+                // Add the applicationUsername and its obfuscated form
                 const rawUsername = this.controller.getApplicationUsername();
                 body.additionalData = {
                     ...body.additionalData ?? {},
@@ -221,7 +221,8 @@ namespace CdvPurchase {
                 }
                 if (!body.additionalData.applicationUsername) delete body.additionalData.applicationUsername;
                 if (rawUsername) {
-                    body.additionalData.obfuscatedUsername = this.controller.obfuscateUsername(rawUsername, receipt.platform);
+                    const obfuscated = this.controller.obfuscateUsername(rawUsername, receipt.platform);
+                    if (obfuscated) body.additionalData.obfuscatedUsername = obfuscated;
                 }
 
                 // Add device information

--- a/src/ts/validator/validator.ts
+++ b/src/ts/validator/validator.ts
@@ -44,6 +44,7 @@ namespace CdvPurchase {
             adapters: Adapters;
             validator_privacy_policy: PrivacyPolicyItem | PrivacyPolicyItem[] | undefined;
             getApplicationUsername(): string | undefined;
+            obfuscateUsername: (applicationUsername: string, platform: CdvPurchase.Platform) => string | undefined;
             verifiedCallbacks: Callbacks<VerifiedReceipt>;
             unverifiedCallbacks: Callbacks<UnverifiedReceipt>;
             finish(receipt:VerifiedReceipt): Promise<void>;
@@ -213,11 +214,16 @@ namespace CdvPurchase {
                 if (!body) return;
 
                 // Add the applicationUsername
+                const rawUsername = this.controller.getApplicationUsername();
                 body.additionalData = {
                     ...body.additionalData ?? {},
-                    applicationUsername: this.controller.getApplicationUsername(),
+                    applicationUsername: rawUsername,
                 }
                 if (!body.additionalData.applicationUsername) delete body.additionalData.applicationUsername;
+                if (rawUsername && body.transaction?.type) {
+                    const platform = body.transaction.type as CdvPurchase.Platform;
+                    body.additionalData.obfuscatedUsername = this.controller.obfuscateUsername(rawUsername, platform);
+                }
 
                 // Add device information
                 body.device = {

--- a/src/ts/validator/validator.ts
+++ b/src/ts/validator/validator.ts
@@ -220,9 +220,8 @@ namespace CdvPurchase {
                     applicationUsername: rawUsername,
                 }
                 if (!body.additionalData.applicationUsername) delete body.additionalData.applicationUsername;
-                if (rawUsername && body.transaction?.type) {
-                    const platform = body.transaction.type as CdvPurchase.Platform;
-                    body.additionalData.obfuscatedUsername = this.controller.obfuscateUsername(rawUsername, platform);
+                if (rawUsername) {
+                    body.additionalData.obfuscatedUsername = this.controller.obfuscateUsername(rawUsername, receipt.platform);
                 }
 
                 // Add device information

--- a/tests/iaptic.test.ts
+++ b/tests/iaptic.test.ts
@@ -173,6 +173,7 @@ describe('CDVPurchase', () => {
           verify: (receipt: CdvPurchase.Receipt | CdvPurchase.Transaction): Promise<void> => new Promise<void>(resolve => resolve()),
         },
         getApplicationUsername: () => 'user',
+        obfuscateUsername: (username: string, platform: CdvPurchase.Platform) => username,
         listener: {
           productsUpdated: (platform: CdvPurchase.Platform, products: CdvPurchase.Product[]): void => {},
           receiptsUpdated: (platform: CdvPurchase.Platform, receipts: CdvPurchase.Receipt[]): void => {},

--- a/tests/obfuscator.test.ts
+++ b/tests/obfuscator.test.ts
@@ -3,7 +3,7 @@ import '../www/store';
 describe('Store.obfuscateUsername', () => {
     afterEach(() => {
         CdvPurchase.store.obfuscator = undefined;
-        (CdvPurchase.store as any)._legacyObfuscatorWarningEmitted = false;
+        (CdvPurchase.store as any)._legacyObfuscatorNoticeEmitted = false;
     });
 
     test('default (legacy) + GOOGLE_PLAY returns raw MD5 hash', () => {
@@ -70,15 +70,17 @@ describe('Store.obfuscateUsername', () => {
             .toBe(CdvPurchase.store.obfuscateUsername('user1', CdvPurchase.Platform.GOOGLE_PLAY));
     });
 
-    test('legacy emits deprecation warning once', () => {
+    test('legacy emits info notice once', () => {
         const previousVerbosity = CdvPurchase.store.verbosity;
-        CdvPurchase.store.verbosity = CdvPurchase.LogLevel.WARNING;
-        const warnSpy = jest.spyOn(CdvPurchase.Logger.console, 'warn').mockImplementation(() => {});
+        CdvPurchase.store.verbosity = CdvPurchase.LogLevel.INFO;
+        const logSpy = jest.spyOn(CdvPurchase.Logger.console, 'log').mockImplementation(() => {});
         CdvPurchase.store.obfuscator = 'legacy';
         CdvPurchase.store.obfuscateUsername('test1', CdvPurchase.Platform.GOOGLE_PLAY);
         CdvPurchase.store.obfuscateUsername('test2', CdvPurchase.Platform.GOOGLE_PLAY);
-        expect(warnSpy).toHaveBeenCalledTimes(1);
-        warnSpy.mockRestore();
+        const noticeCalls = logSpy.mock.calls.filter(args =>
+            args.some(a => typeof a === 'string' && a.includes('store.obfuscator defaults to "legacy"')));
+        expect(noticeCalls).toHaveLength(1);
+        logSpy.mockRestore();
         CdvPurchase.store.verbosity = previousVerbosity;
     });
 });

--- a/tests/obfuscator.test.ts
+++ b/tests/obfuscator.test.ts
@@ -1,0 +1,84 @@
+import '../www/store';
+
+describe('Store.obfuscateUsername', () => {
+    afterEach(() => {
+        CdvPurchase.store.obfuscator = undefined;
+        (CdvPurchase.store as any)._legacyObfuscatorWarningEmitted = false;
+    });
+
+    test('default (legacy) + GOOGLE_PLAY returns raw MD5 hash', () => {
+        CdvPurchase.store.obfuscator = undefined;
+        const result = CdvPurchase.store.obfuscateUsername('hello', CdvPurchase.Platform.GOOGLE_PLAY);
+        // MD5 of "hello" is 5d41402abc4b2a76b9719d911017c592 (32 hex chars, no dashes)
+        expect(result).toBe('5d41402abc4b2a76b9719d911017c592');
+        expect(result).toHaveLength(32);
+    });
+
+    test('default (legacy) + APPLE_APPSTORE returns UUIDv3 format', () => {
+        CdvPurchase.store.obfuscator = undefined;
+        const result = CdvPurchase.store.obfuscateUsername('hello', CdvPurchase.Platform.APPLE_APPSTORE);
+        expect(result).toBe('5d41402a-bc4b-3a76-8971-9d911017c592');
+        expect(result).toHaveLength(36);
+    });
+
+    test('legacy + GOOGLE_PLAY returns raw MD5 hash', () => {
+        CdvPurchase.store.obfuscator = 'legacy';
+        const result = CdvPurchase.store.obfuscateUsername('hello', CdvPurchase.Platform.GOOGLE_PLAY);
+        expect(result).toBe('5d41402abc4b2a76b9719d911017c592');
+    });
+
+    test('legacy + APPLE_APPSTORE returns UUIDv3 format', () => {
+        CdvPurchase.store.obfuscator = 'legacy';
+        const result = CdvPurchase.store.obfuscateUsername('hello', CdvPurchase.Platform.APPLE_APPSTORE);
+        expect(result).toBe('5d41402a-bc4b-3a76-8971-9d911017c592');
+    });
+
+    test('uuid + any platform returns UUIDv3 format', () => {
+        CdvPurchase.store.obfuscator = 'uuid';
+        const google = CdvPurchase.store.obfuscateUsername('hello', CdvPurchase.Platform.GOOGLE_PLAY);
+        const apple = CdvPurchase.store.obfuscateUsername('hello', CdvPurchase.Platform.APPLE_APPSTORE);
+        expect(google).toBe('5d41402a-bc4b-3a76-8971-9d911017c592');
+        expect(apple).toBe('5d41402a-bc4b-3a76-8971-9d911017c592');
+    });
+
+    test('disabled + any platform returns raw value', () => {
+        CdvPurchase.store.obfuscator = 'disabled';
+        expect(CdvPurchase.store.obfuscateUsername('user123', CdvPurchase.Platform.GOOGLE_PLAY)).toBe('user123');
+        expect(CdvPurchase.store.obfuscateUsername('user123', CdvPurchase.Platform.APPLE_APPSTORE)).toBe('user123');
+    });
+
+    test('custom function receives username and platform', () => {
+        CdvPurchase.store.obfuscator = (username: string, platform: CdvPurchase.Platform) => {
+            return `custom-${platform}-${username}`;
+        };
+        expect(CdvPurchase.store.obfuscateUsername('alice', CdvPurchase.Platform.GOOGLE_PLAY)).toBe('custom-android-playstore-alice');
+    });
+
+    test('returns undefined for empty input', () => {
+        CdvPurchase.store.obfuscator = 'legacy';
+        expect(CdvPurchase.store.obfuscateUsername('', CdvPurchase.Platform.GOOGLE_PLAY)).toBeUndefined();
+    });
+
+    test('returns undefined for undefined obfuscator input', () => {
+        CdvPurchase.store.obfuscator = 'legacy';
+        expect(CdvPurchase.store.obfuscateUsername(undefined as any, CdvPurchase.Platform.GOOGLE_PLAY)).toBeUndefined();
+    });
+
+    test('legacy is deterministic', () => {
+        CdvPurchase.store.obfuscator = 'legacy';
+        expect(CdvPurchase.store.obfuscateUsername('user1', CdvPurchase.Platform.GOOGLE_PLAY))
+            .toBe(CdvPurchase.store.obfuscateUsername('user1', CdvPurchase.Platform.GOOGLE_PLAY));
+    });
+
+    test('legacy emits deprecation warning once', () => {
+        const previousVerbosity = CdvPurchase.store.verbosity;
+        CdvPurchase.store.verbosity = CdvPurchase.LogLevel.WARNING;
+        const warnSpy = jest.spyOn(CdvPurchase.Logger.console, 'warn').mockImplementation(() => {});
+        CdvPurchase.store.obfuscator = 'legacy';
+        CdvPurchase.store.obfuscateUsername('test1', CdvPurchase.Platform.GOOGLE_PLAY);
+        CdvPurchase.store.obfuscateUsername('test2', CdvPurchase.Platform.GOOGLE_PLAY);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        warnSpy.mockRestore();
+        CdvPurchase.store.verbosity = previousVerbosity;
+    });
+});

--- a/tests/to-uuid.test.ts
+++ b/tests/to-uuid.test.ts
@@ -1,0 +1,48 @@
+import '../www/store';
+
+describe('Utils.md5toUUID', () => {
+    test('converts MD5 hash to UUIDv3-like format', () => {
+        // MD5 of "hello" is 5d41402abc4b2a76b9719d911017c592
+        // UUIDv3 format: xxxxxxxx-xxxx-3xxx-8xxx-xxxxxxxxxxxx
+        // Position 12: version '3', position 16: variant '8'
+        const result = CdvPurchase.Utils.md5toUUID('hello');
+        expect(result).toBe('5d41402a-bc4b-3a76-8971-9d911017c592');
+    });
+
+    test('produces valid UUID format', () => {
+        const result = CdvPurchase.Utils.md5toUUID('test');
+        expect(result).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+
+    test('version nibble is 3 (UUIDv3)', () => {
+        const result = CdvPurchase.Utils.md5toUUID('hello');
+        expect(result?.charAt(14)).toBe('3');
+    });
+
+    test('variant nibble is 8 (RFC 4122)', () => {
+        const result = CdvPurchase.Utils.md5toUUID('hello');
+        expect(result?.charAt(19)).toBe('8');
+    });
+
+    test('is deterministic', () => {
+        expect(CdvPurchase.Utils.md5toUUID('user1')).toBe(CdvPurchase.Utils.md5toUUID('user1'));
+    });
+
+    test('different inputs produce different outputs', () => {
+        expect(CdvPurchase.Utils.md5toUUID('user1')).not.toBe(CdvPurchase.Utils.md5toUUID('user2'));
+    });
+
+    test('returns empty string for empty input', () => {
+        expect(CdvPurchase.Utils.md5toUUID('')).toBe('');
+    });
+
+    test('preserves remaining MD5 hex in UUID', () => {
+        // MD5 of "a" is 0cc175b9c0f1b6a831c399e269772661
+        const result = CdvPurchase.Utils.md5toUUID('a');
+        const md5 = CdvPurchase.Utils.md5('a');
+        // First 8 hex chars of UUID should match first 8 of MD5
+        expect(result.substring(0, 8)).toBe(md5.substring(0, 8));
+        // Last 12 hex chars of UUID should match last 12 of MD5
+        expect(result.substring(24)).toBe(md5.substring(20));
+    });
+});

--- a/tests/validator-request-body.test.ts
+++ b/tests/validator-request-body.test.ts
@@ -1,0 +1,130 @@
+import '../www/store';
+
+// These tests capture the request body that Validator.runValidatorRequest
+// sends to ajax. They exercise the obfuscatedUsername wiring without
+// touching a real native bridge.
+
+function makeLogger(): CdvPurchase.Logger {
+    const noop = () => {};
+    return {
+        verbosity: CdvPurchase.LogLevel.QUIET,
+        error: noop,
+        warn: noop,
+        info: noop,
+        debug: noop,
+        child: () => makeLogger(),
+        logger: { log: noop },
+    } as unknown as CdvPurchase.Logger;
+}
+
+function makeAdapter(platform: CdvPurchase.Platform): CdvPurchase.Adapter {
+    return {
+        id: platform,
+        name: `adapter-${platform}`,
+        ready: true,
+        products: [],
+        receipts: [],
+        isSupported: true,
+        receiptValidationBody: async () => ({
+            id: 'com.test.product',
+            type: CdvPurchase.ProductType.CONSUMABLE,
+            transaction: { type: 'test', id: 't1' },
+        }),
+        handleReceiptValidationResponse: async () => {},
+    } as unknown as CdvPurchase.Adapter;
+}
+
+function makeReceipt(platform: CdvPurchase.Platform): CdvPurchase.Receipt {
+    return new CdvPurchase.Receipt(platform, {
+        verify: async () => {},
+        finish: async () => {},
+    });
+}
+
+async function captureRequestBody(platform: CdvPurchase.Platform, store: CdvPurchase.Store): Promise<any> {
+    const adapter = makeAdapter(platform);
+    const verifiedCallbacks = new CdvPurchase.Internal.Callbacks<CdvPurchase.VerifiedReceipt>(makeLogger(), 'verified');
+    const unverifiedCallbacks = new CdvPurchase.Internal.Callbacks<CdvPurchase.UnverifiedReceipt>(makeLogger(), 'unverified');
+
+    const controller: CdvPurchase.Internal.ValidatorController = {
+        validator: 'https://example.test/validate',
+        localReceipts: [],
+        adapters: { find: () => adapter } as unknown as CdvPurchase.Internal.Adapters,
+        validator_privacy_policy: undefined,
+        getApplicationUsername: () => store.getApplicationUsername(),
+        obfuscateUsername: (u: string, p: CdvPurchase.Platform) => store.obfuscateUsername(u, p),
+        verifiedCallbacks,
+        unverifiedCallbacks,
+        finish: async () => {},
+    };
+
+    let capturedBody: any = undefined;
+    const originalAjax = CdvPurchase.Utils.ajax;
+    (CdvPurchase.Utils as any).ajax = (_log: CdvPurchase.Logger, opts: any) => {
+        capturedBody = opts.data;
+        // Respond with a minimal valid success payload so the pipeline settles.
+        setTimeout(() => opts.success({
+            ok: true,
+            data: { id: 'com.test.product', transaction: { type: 'test' } },
+        }), 0);
+        return { done: () => {} };
+    };
+
+    try {
+        const validator = new CdvPurchase.Internal.Validator(controller, makeLogger());
+        validator.add(makeReceipt(platform));
+        validator.run();
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+        await new Promise(r => setTimeout(r, 50));
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+    } finally {
+        (CdvPurchase.Utils as any).ajax = originalAjax;
+    }
+
+    return capturedBody;
+}
+
+describe('Validator request body — obfuscatedUsername wiring', () => {
+    afterEach(() => {
+        CdvPurchase.store.obfuscator = undefined;
+        CdvPurchase.store.applicationUsername = undefined;
+        (CdvPurchase.store as any)._legacyObfuscatorNoticeEmitted = false;
+    });
+
+    test('omits obfuscatedUsername when applicationUsername is unset', async () => {
+        CdvPurchase.store.applicationUsername = undefined;
+        const body = await captureRequestBody(CdvPurchase.Platform.GOOGLE_PLAY, CdvPurchase.store);
+        expect(body.additionalData?.applicationUsername).toBeUndefined();
+        expect(body.additionalData?.obfuscatedUsername).toBeUndefined();
+    });
+
+    test('includes both raw and obfuscated username on GOOGLE_PLAY with legacy obfuscator', async () => {
+        CdvPurchase.store.applicationUsername = 'hello';
+        CdvPurchase.store.obfuscator = 'legacy';
+        const body = await captureRequestBody(CdvPurchase.Platform.GOOGLE_PLAY, CdvPurchase.store);
+        expect(body.additionalData.applicationUsername).toBe('hello');
+        expect(body.additionalData.obfuscatedUsername).toBe('5d41402abc4b2a76b9719d911017c592');
+    });
+
+    test('uuid obfuscator sends UUIDv3 format', async () => {
+        CdvPurchase.store.applicationUsername = 'hello';
+        CdvPurchase.store.obfuscator = 'uuid';
+        const body = await captureRequestBody(CdvPurchase.Platform.APPLE_APPSTORE, CdvPurchase.store);
+        expect(body.additionalData.applicationUsername).toBe('hello');
+        expect(body.additionalData.obfuscatedUsername).toBe('5d41402a-bc4b-3a76-8971-9d911017c592');
+    });
+
+    test('disabled obfuscator sends raw value as obfuscatedUsername', async () => {
+        CdvPurchase.store.applicationUsername = 'hello';
+        CdvPurchase.store.obfuscator = 'disabled';
+        const body = await captureRequestBody(CdvPurchase.Platform.GOOGLE_PLAY, CdvPurchase.store);
+        expect(body.additionalData.obfuscatedUsername).toBe('hello');
+    });
+
+    test('custom obfuscator value reaches the validator body', async () => {
+        CdvPurchase.store.applicationUsername = 'alice';
+        CdvPurchase.store.obfuscator = (u, p) => `cf-${p}-${u}`;
+        const body = await captureRequestBody(CdvPurchase.Platform.GOOGLE_PLAY, CdvPurchase.store);
+        expect(body.additionalData.obfuscatedUsername).toBe('cf-android-playstore-alice');
+    });
+});

--- a/tests/validator-response-validation.test.ts
+++ b/tests/validator-response-validation.test.ts
@@ -63,6 +63,7 @@ async function runValidator(payload: unknown): Promise<RunResult> {
     adapters: { find: () => adapter } as unknown as CdvPurchase.Internal.Adapters,
     validator_privacy_policy: undefined,
     getApplicationUsername: () => undefined,
+    obfuscateUsername: (_applicationUsername: string, _platform: CdvPurchase.Platform) => undefined,
     verifiedCallbacks,
     unverifiedCallbacks,
     finish: async () => {},


### PR DESCRIPTION
## Summary

Adds `store.obfuscator` to make the `applicationUsername` obfuscation strategy configurable, and fixes the broken `applicationUsername`/`appAccountToken` on Apple SK2 (issue #1665).

### Problem

- **Apple SK2**: `applicationUsername` passed via `store.order()` was broken because `UUID(uuidString: username) ?? UUID()` in the Swift bridge fell back to a random UUID when the username wasn't a valid UUID string.
- No way to control or disable the MD5 hashing of `applicationUsername` (issue #1660).

### Solution

Adds `store.obfuscator` property with 4 modes:

| Mode | Google Play | Apple SK1 (deprecated) | Apple SK2 |
|------|-------------|------------------------|-----------|
| `'uuid'` (recommended) | UUIDv3 format | UUIDv3 format | UUIDv3 format |
| `'legacy'` (default) | MD5 hash (32 hex) | raw value | UUIDv3 format |
| `'disabled'` | raw value | raw value | raw value (must be valid UUID) |
| Custom function | `fn(username, 'android-playstore')` | `fn(username, 'ios-appstore')` → UUID | `fn(username, 'ios-appstore')` → UUID |

`'uuid'` is the recommended setting for new integrations. The default stays at `'legacy'` only so existing server-side modules that already correlate against the raw 32-hex MD5 value keep working.

### Deprecation: `additionalData.applicationUsername`

Passing `applicationUsername` per-transaction via `additionalData` is now **deprecated and ignored**. Set `store.applicationUsername` (or pass a `() => string` getter) instead. This avoids surprising side effects and ensures the value used for the native API matches the value sent to the validator later. Calls that pass it emit a one-shot warning.

### Backward Compatibility

With the default `'legacy'` mode, **no breaking changes for Google Play and SK1**:
- Google Play: still sends MD5 hash
- Apple SK1: still sends raw username
- Apple SK2: now sends a deterministic UUIDv3 instead of a random UUID (**fix**)
- Validator body: sends raw `applicationUsername` alongside the new `obfuscatedUsername` (additive)

A one-shot info notice points new integrations at `'uuid'`.

### Changes

- **`Utils.md5toUUID()`** — new utility to format MD5 hashes as UUIDv3 (deterministic, valid UUID)
- **`Store.obfuscator`** — new property (`'legacy' | 'uuid' | 'disabled' | custom function`)
- **`Store.obfuscateUsername()`** — applies the obfuscation strategy per-platform
- **Google Play adapter** — uses `obfuscateUsername()`, no longer mutates caller's `additionalData`
- **Apple adapter** — new `resolveBridgeUsername()` keeps SK1+legacy raw behavior, obfuscates everywhere else
- **Capacitor Swift bridge** — removes `?? UUID()` random fallback; logs when `applicationUsername` is not a valid UUID
- **Validator body** — adds `obfuscatedUsername` alongside `applicationUsername` (guarded against `undefined`)
- **`additionalData.applicationUsername`** — deprecated; one-shot warning when used

### Test plan

- [x] Unit tests pass (80 total: 8 for md5toUUID, 11 for obfuscator, 5 for validator request body, 56 existing)
- [x] TypeScript compilation (`tsc --noEmit`) passes
- [x] `make all` (compile, test, javalint, typedoc, capacitor-package) passes
- [ ] Manual testing on Android device with `cordova-purchase-micro-example`
- [x] Manual testing on iOS device with StoreKit 2

Closes #1665
Related #1660