### PR TITLE
fix: canPurchase returns false for pending and unfinished transactions (#1705)

### DIFF
--- a/src/ts/internal/local-receipts.ts
+++ b/src/ts/internal/local-receipts.ts
@@ -43,8 +43,9 @@ namespace CdvPurchase {
         const transaction = LocalReceipts.find(localReceipts, product);
         if (!transaction) return true;
         if (transaction.isConsumed) return true;
+        if (transaction.isPending) return false;
         if (transaction.expirationDate) return transaction.expirationDate.getTime() <= +new Date();
-        return true;
+        return false;
       }
     }
   }

--- a/tests/local-receipts.test.ts
+++ b/tests/local-receipts.test.ts
@@ -1,0 +1,62 @@
+import '../www/store';
+
+/**
+ * Unit tests for Internal.LocalReceipts.canPurchase — covers the fix for
+ * issue #1705: canPurchase used to return true for transactions that were
+ * approved-but-not-finished (and for transactions stuck in Google Play's
+ * PENDING state), allowing users to start a second purchase while the
+ * previous one was still in flight.
+ */
+describe('Internal.LocalReceipts.canPurchase (#1705)', () => {
+
+    const { LocalReceipts } = CdvPurchase.Internal;
+    const PLATFORM = CdvPurchase.Platform.TEST;
+    const PRODUCT_ID = 'consumable.coins';
+
+    function makeReceipt(tx: Partial<CdvPurchase.Transaction>): CdvPurchase.Receipt {
+        const transaction = {
+            products: [{ id: PRODUCT_ID }],
+            platform: PLATFORM,
+            ...tx,
+        } as unknown as CdvPurchase.Transaction;
+        return {
+            platform: PLATFORM,
+            transactions: [transaction],
+        } as unknown as CdvPurchase.Receipt;
+    }
+
+    it('returns true when no receipt exists for the product', () => {
+        expect(LocalReceipts.canPurchase([], { id: PRODUCT_ID, platform: PLATFORM })).toBe(true);
+    });
+
+    it('returns true after a consumable has been consumed (finished)', () => {
+        const receipts = [makeReceipt({ isConsumed: true })];
+        expect(LocalReceipts.canPurchase(receipts, { id: PRODUCT_ID, platform: PLATFORM })).toBe(true);
+    });
+
+    it('returns false when a transaction is approved but not finished', () => {
+        const receipts = [makeReceipt({ isConsumed: false })];
+        expect(LocalReceipts.canPurchase(receipts, { id: PRODUCT_ID, platform: PLATFORM })).toBe(false);
+    });
+
+    it('returns false when a Google Play transaction is still pending payment', () => {
+        const receipts = [makeReceipt({ isPending: true })];
+        expect(LocalReceipts.canPurchase(receipts, { id: PRODUCT_ID, platform: PLATFORM })).toBe(false);
+    });
+
+    it('returns false when a subscription is still active', () => {
+        const future = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        const receipts = [makeReceipt({ expirationDate: future })];
+        expect(LocalReceipts.canPurchase(receipts, { id: PRODUCT_ID, platform: PLATFORM })).toBe(false);
+    });
+
+    it('returns true when a subscription has expired', () => {
+        const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+        const receipts = [makeReceipt({ expirationDate: past })];
+        expect(LocalReceipts.canPurchase(receipts, { id: PRODUCT_ID, platform: PLATFORM })).toBe(true);
+    });
+
+    it('returns false when no product is provided', () => {
+        expect(LocalReceipts.canPurchase([], undefined)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes #1705 — `Offer.canPurchase` / `Product.canPurchase` returned `true` while a previous transaction for the same product was still approved-but-not-finished, letting users start a second purchase before the first completed.
- Adds an `isPending` check (Google Play deferred-payment state) and flips the trailing default to `false` so an existing unconsumed non-expiring transaction blocks repurchase until `finish()` is called.
- Mirrors the structure already used by the neighbouring `isOwned()` helper in the same file.

## How pending purchases clear
- **Google Play `isPending`**: resolves automatically — when the deferred payment clears, the Play bridge re-emits the purchase and `refresh()` rewrites `isPending` to `false`.
- **Approved-but-not-finished consumables (iOS & Android)**: clear when the app completes the normal `approved → verify() → verified → finish() → finished` lifecycle; once `isConsumed` becomes `true`, `canPurchase` returns `true` again.

## Test plan
- [x] New unit suite `tests/local-receipts.test.ts` covers: no receipt, consumed, pending, approved-not-finished, active subscription, expired subscription, missing product
- [x] `make all` (tsc + jest + javalint + typedoc + capacitor-package) green
- [x] All 9 existing test suites still pass (87 tests)