### PR TITLE
Send device information from @capacitor/device when available

### DIFF
--- a/src/ts/validator/validator-deviceinfo.ts
+++ b/src/ts/validator/validator-deviceinfo.ts
@@ -64,7 +64,44 @@ namespace CdvPurchase {
                     return ['analytics', 'support', 'fraud'];
             }
 
-            export function getDeviceInfo(store: PrivacyPolicyProvider): DeviceInfo {
+            /** Map @capacitor/device data to the cordova-plugin-device format.
+             *
+             * Used as a fallback when cordova-plugin-device isn't installed (typically
+             * in Capacitor apps). Detected through the plugin proxy that Capacitor
+             * registers at window.Capacitor.Plugins.Device, so the plugin doesn't
+             * need a dependency on @capacitor/device.
+             *
+             * @param includeId fetch the device identifier (requires user consent) */
+            async function getCapacitorDevice(includeId: boolean): Promise<any> {
+                const capacitorDevice = (window as any).Capacitor?.Plugins?.Device;
+                if (!capacitorDevice) return {};
+                const device: any = {};
+                try {
+                    const info = await capacitorDevice.getInfo();
+                    if (isObject(info)) {
+                        device.model = info.model;
+                        // match cordova-plugin-device casing ("iOS", "Android")
+                        device.platform = info.operatingSystem === 'ios' ? 'iOS'
+                            : info.operatingSystem === 'android' ? 'Android'
+                            : info.operatingSystem;
+                        device.version = info.osVersion;
+                        device.manufacturer = info.manufacturer;
+                        device.isVirtual = info.isVirtual;
+                    }
+                }
+                catch (e) { /* @capacitor/device not functional, skip device info */ }
+                if (includeId) {
+                    try {
+                        const id = await capacitorDevice.getId();
+                        // "identifier" since @capacitor/device v4, "uuid" before
+                        device.uuid = id?.identifier ?? id?.uuid;
+                    }
+                    catch (e) { /* ignore, "uuid" stays undefined */ }
+                }
+                return device;
+            }
+
+            export async function getDeviceInfo(store: PrivacyPolicyProvider): Promise<DeviceInfo> {
 
                 const privacyPolicy = getPrivacyPolicy(store); // string[]
                 function allowed(policy: PrivacyPolicyItem) {
@@ -83,8 +120,11 @@ namespace CdvPurchase {
                     Ionic: any;
                 } = window as any;
 
-                // the cordova-plugin-device global object
-                const device: any = isObject(wdw.device) ? wdw.device : {};
+                // the cordova-plugin-device global object,
+                // with @capacitor/device as a fallback
+                const device: any = isObject(wdw.device)
+                    ? wdw.device
+                    : await getCapacitorDevice(allowed('tracking') || allowed('fraud'));
 
                 // Send the receipt validator information about the device.
                 // This will allow to make vendor or device specific fixes and detect class
@@ -141,7 +181,7 @@ namespace CdvPurchase {
                         if (device.model)
                             fingerprint += '/' + device.model;
                         if (device.manufacturer)
-                            fingerprint = '/' + device.manufacturer;
+                            fingerprint += '/' + device.manufacturer;
                     }
                     // Fingerprint is hashed to keep required level of privacy.
                     if (fingerprint)

--- a/src/ts/validator/validator.ts
+++ b/src/ts/validator/validator.ts
@@ -228,7 +228,7 @@ namespace CdvPurchase {
                 // Add device information
                 body.device = {
                     ...body.device ?? {},
-                    ...CdvPurchase.Validator.Internal.getDeviceInfo(this.controller),
+                    ...await CdvPurchase.Validator.Internal.getDeviceInfo(this.controller),
                 }
 
                 // Add legacy pricing information

--- a/tests/validator-deviceinfo.test.ts
+++ b/tests/validator-deviceinfo.test.ts
@@ -1,0 +1,132 @@
+import '../www/store';
+
+// Tests for Validator.Internal.getDeviceInfo: device information gathering
+// from cordova-plugin-device (window.device) and @capacitor/device
+// (window.Capacitor.Plugins.Device).
+
+const defaultPolicyStore = { validator_privacy_policy: undefined }; // analytics, support, fraud
+const trackingStore = { validator_privacy_policy: ['analytics', 'support', 'fraud', 'tracking'] as CdvPurchase.PrivacyPolicyItem[] };
+
+function setCordovaDevice(device: any) {
+    (window as any).device = device;
+}
+
+function setCapacitorDevice(plugin: { getInfo?: () => Promise<any>, getId?: () => Promise<any> }) {
+    (window as any).Capacitor = { Plugins: { Device: plugin } };
+}
+
+async function getDeviceInfo(store: any): Promise<CdvPurchase.Validator.DeviceInfo> {
+    return await (CdvPurchase.Validator.Internal.getDeviceInfo(store) as any);
+}
+
+describe('Validator.Internal.getDeviceInfo', () => {
+
+    afterEach(() => {
+        delete (window as any).device;
+        delete (window as any).Capacitor;
+    });
+
+    test('reports only the plugin version when no device plugin is installed', async () => {
+        const info = await getDeviceInfo(defaultPolicyStore);
+        expect(info.plugin).toBe('cordova-plugin-purchase/' + CdvPurchase.PLUGIN_VERSION);
+        expect(info.model).toBeUndefined();
+        expect(info.platform).toBeUndefined();
+    });
+
+    test('uses cordova-plugin-device data when window.device is present', async () => {
+        setCordovaDevice({
+            cordova: '12.0.0',
+            model: 'Pixel 7',
+            platform: 'Android',
+            version: '14',
+            manufacturer: 'Google',
+            isVirtual: true,
+        });
+        const info = await getDeviceInfo(defaultPolicyStore);
+        expect(info.cordova).toBe('12.0.0');
+        expect(info.model).toBe('Pixel 7');
+        expect(info.platform).toBe('Android');
+        expect(info.version).toBe('14');
+        expect(info.manufacturer).toBe('Google');
+        expect(info.isVirtual).toBe(true);
+    });
+
+    test('falls back to @capacitor/device when window.device is absent', async () => {
+        setCapacitorDevice({
+            getInfo: async () => ({
+                model: 'SM-A536B',
+                operatingSystem: 'android',
+                osVersion: '14',
+                manufacturer: 'samsung',
+                isVirtual: true,
+                platform: 'android',
+                webViewVersion: '124.0',
+            }),
+            getId: async () => ({ identifier: 'cap-device-id' }),
+        });
+        const info = await getDeviceInfo(defaultPolicyStore);
+        expect(info.model).toBe('SM-A536B');
+        expect(info.platform).toBe('Android'); // normalized to cordova-plugin-device casing
+        expect(info.version).toBe('14');
+        expect(info.manufacturer).toBe('samsung');
+        expect(info.isVirtual).toBe(true);
+        expect(info.cordova).toBeUndefined();
+    });
+
+    test('normalizes capacitor operatingSystem "ios" to "iOS"', async () => {
+        setCapacitorDevice({
+            getInfo: async () => ({ model: 'iPhone15,2', operatingSystem: 'ios', osVersion: '17.4' }),
+        });
+        const info = await getDeviceInfo(defaultPolicyStore);
+        expect(info.platform).toBe('iOS');
+        expect(info.model).toBe('iPhone15,2');
+        expect(info.version).toBe('17.4');
+    });
+
+    test('capacitor device id is used as uuid only with the tracking policy', async () => {
+        setCapacitorDevice({
+            getInfo: async () => ({ model: 'Pixel 7', operatingSystem: 'android' }),
+            getId: async () => ({ identifier: 'cap-device-id' }),
+        });
+        const noTracking = await getDeviceInfo(defaultPolicyStore);
+        expect(noTracking.uuid).toBeUndefined();
+        const withTracking = await getDeviceInfo(trackingStore);
+        expect(withTracking.uuid).toBe('cap-device-id');
+    });
+
+    test('fraud fingerprint is computed from the capacitor device id without tracking policy', async () => {
+        setCapacitorDevice({
+            getInfo: async () => ({ model: 'Pixel 7', operatingSystem: 'android' }),
+            getId: async () => ({ identifier: 'cap-device-id' }),
+        });
+        const info = await getDeviceInfo(defaultPolicyStore);
+        expect(info.uuid).toBeUndefined();
+        expect(info.fingerprint).toBe(CdvPurchase.Utils.md5('uuid:cap-device-id'));
+    });
+
+    test('window.device takes precedence over @capacitor/device', async () => {
+        setCordovaDevice({ model: 'CordovaModel', platform: 'Android' });
+        setCapacitorDevice({
+            getInfo: async () => ({ model: 'CapacitorModel', operatingSystem: 'android' }),
+        });
+        const info = await getDeviceInfo(defaultPolicyStore);
+        expect(info.model).toBe('CordovaModel');
+    });
+
+    test('survives a failing @capacitor/device plugin', async () => {
+        setCapacitorDevice({
+            getInfo: async () => { throw new Error('boom'); },
+            getId: async () => { throw new Error('boom'); },
+        });
+        const info = await getDeviceInfo(trackingStore);
+        expect(info.plugin).toBe('cordova-plugin-purchase/' + CdvPurchase.PLUGIN_VERSION);
+        expect(info.model).toBeUndefined();
+        expect(info.uuid).toBeUndefined();
+    });
+
+    test('fallback fingerprint combines model and manufacturer', async () => {
+        setCordovaDevice({ model: 'Pixel 7', manufacturer: 'Google' });
+        const info = await getDeviceInfo(defaultPolicyStore);
+        expect(info.fingerprint).toBe(CdvPurchase.Utils.md5('/Pixel 7/Google'));
+    });
+});


### PR DESCRIPTION
Fixes #1708

## Problem

The device information included in receipt validation requests was gathered exclusively from the `window.device` global installed by `cordova-plugin-device`. Capacitor apps typically use `@capacitor/device` instead, which registers no such global — so validation requests from `capacitor-plugin-cdv-purchase` apps carried no device model, OS version, manufacturer, uuid or fraud fingerprint.

## Solution

When `window.device` is absent, fall back to the plugin proxy that Capacitor registers at `window.Capacitor.Plugins.Device` when `@capacitor/device` is installed. No new dependency is needed.

- `getInfo()` provides `model`, `platform` (`operatingSystem`, normalized to the cordova-plugin-device casing `iOS`/`Android`), `version` (`osVersion`), `manufacturer` and `isVirtual`.
- `getId()` provides the device identifier, fetched only when the privacy policy allows `tracking` or `fraud`; it is reported as `uuid` only under the `tracking` policy, and otherwise only hashed into the fraud fingerprint.
- `cordova-plugin-device` still takes precedence when both are present.
- `getDeviceInfo()` becomes async; its only call site (`buildRequestBody`) already was.

Also fixes a pre-existing bug in the fallback fraud fingerprint: it assigned the manufacturer instead of appending it, discarding the device model (`fingerprint = '/' + manufacturer` → `fingerprint += '/' + manufacturer`).

## Testing

- 9 new unit tests in `tests/validator-deviceinfo.test.ts` covering the cordova path, the capacitor fallback, platform normalization, privacy-policy gating of the identifier, plugin failure resilience, precedence, and the fingerprint fix.
- End-to-end on a Play-enabled Android emulator (Pixel 4, API 35) with the Capacitor subscriptions example app (`@capacitor/device` installed, no cordova-plugin-device): purchased a test subscription and confirmed the validation request now includes the device info, with the validator round-trip succeeding:

```
[SubscriptionsExample] INFO: VALIDATOR_REQUEST_DEVICE => {"plugin":"cordova-plugin-purchase/13.17.0","model":"sdk_gphone64_arm64","platform":"Android","version":"15","manufacturer":"Google","isVirtual":true,"fingerprint":"7c68b00b4fcf949a5e411b64991ceb72"}
[CdvPurchase.Validator] DEBUG: validator success, response: {"ok":true,...}
```